### PR TITLE
master

### DIFF
--- a/Pharo/BaselineOfPharoJS/ManifestBaselineOfPharoJS.class.st
+++ b/Pharo/BaselineOfPharoJS/ManifestBaselineOfPharoJS.class.st
@@ -1,0 +1,18 @@
+"
+I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+"
+Class {
+	#name : #ManifestBaselineOfPharoJS,
+	#superclass : #PackageManifest,
+	#category : #'BaselineOfPharoJS-Manifest'
+}
+
+{ #category : #'code-critics' }
+ManifestBaselineOfPharoJS class >> ruleRBLongMethodsRuleV1FalsePositive [
+	^ #(#(#(#RGClassDefinition #(#BaselineOfPharoJS)) #'2020-02-14T19:08:56.237579-05:00') )
+]
+
+{ #category : #'code-critics' }
+ManifestBaselineOfPharoJS class >> ruleRBUtilityMethodsRuleV1FalsePositive [
+	^ #(#(#(#RGClassDefinition #(#BaselineOfPharoJS)) #'2020-02-14T19:09:03.794682-05:00') )
+]

--- a/Pharo/PharoJsApp/PjApplication.class.st
+++ b/Pharo/PharoJsApp/PjApplication.class.st
@@ -55,6 +55,12 @@ PjApplication class >> headerLine [
 	^nil
 ]
 
+{ #category : #accessing }
+PjApplication class >> pharoJsSelectorPrefix [
+	<pharoJsSkip>
+	^ PjTranspiler pharoJsSelectorPrefix
+]
+
 { #category : #'instance creation' }
 PjApplication class >> resetCurrentInstance [
 	currentInstance := nil.

--- a/Pharo/PharoJsBridge/PjBridge.class.st
+++ b/Pharo/PharoJsBridge/PjBridge.class.st
@@ -54,7 +54,8 @@ Class {
 		'blockClosures',
 		'client',
 		'runOnPharo',
-		'shouldStartJsInterpreter'
+		'shouldStartJsInterpreter',
+		'transpiler'
 	],
 	#category : #'PharoJsBridge-Kernel'
 }
@@ -163,7 +164,7 @@ PjBridge >> blockClosure: aBlockClosure [
 				^ PjJavascriptError signal: 'Block cannot have return' ].
 		thisArg := aBlockClosure argumentNames findFirst: [ : name | name='this' ].
 		proxy := self evalJavascript: self websocketDelegateClassName,
-			'.', PjTranspiler pharoJsSelectorPrefix, 'default().', PjTranspiler pharoJsSelectorPrefix, 'makeBlockClosureProxy_(',thisArg asString,')'.
+			'.', transpiler pharoJsSelectorPrefix, 'default().', transpiler pharoJsSelectorPrefix, 'makeBlockClosureProxy_(',thisArg asString,')'.
 		proxy closure: aBlockClosure.
 		proxy
 	]
@@ -183,9 +184,11 @@ PjBridge >> client [
 PjBridge >> client: aClient [
 	client := aClient.
 	client bridge: self.
+	transpiler := aClient exporter transpiler.
+
 ]
 
-{ #category : #'initialize-release' }
+{ #category : #initialization }
 PjBridge >> clientTitle [
 	^self client title
 ]
@@ -200,7 +203,7 @@ PjBridge >> defaultClientClass [
 	^self class defaultClientClass
 ]
 
-{ #category : #'initialize-release' }
+{ #category : #initialization }
 PjBridge >> defaultCommunicationTrialsCount [
 	^100
 ]
@@ -349,7 +352,7 @@ PjBridge >> handOffResult: aBlock [
 	]
 ]
 
-{ #category : #'initialize-release' }
+{ #category : #initialization }
 PjBridge >> initialize [
 	super initialize.
 	executingCallbacks := false.
@@ -456,7 +459,7 @@ PjBridge >> port [
 	^self server port
 ]
 
-{ #category : #'initialize-release' }
+{ #category : #initialization }
 PjBridge >> port: portNumber [
 	self server port: portNumber
 ]
@@ -470,7 +473,7 @@ PjBridge >> proxies [
 PjBridge >> resetClient [
 	| oldWebSocket |
 	oldWebSocket := self webSocket.
-	self sendMessage: self websocketDelegateClassName, '.', PjTranspiler pharoJsSelectorPrefix, 'reload_(true)'.
+	self sendMessage: self websocketDelegateClassName, '.', transpiler pharoJsSelectorPrefix, 'reload_(true)'.
 	self resetProxies.
 	self client reset.
 	self 
@@ -484,7 +487,7 @@ PjBridge >> resetClient [
 
 ]
 
-{ #category : #'initialize-release' }
+{ #category : #initialization }
 PjBridge >> resetProxies [
 	proxies := nil.
 	"Ensure that proxies are actually suppressed which lead to releasing the objects on the JS side"
@@ -531,7 +534,7 @@ PjBridge >> serverAddress [
 	self shouldBeImplemented.
 ]
 
-{ #category : #'initialize-release' }
+{ #category : #initialization }
 PjBridge >> serverClass [
 	^PjServer
 ]
@@ -626,7 +629,7 @@ PjBridge >> timeout: aDuration [
 	timeout := (aDuration isKindOf: Duration) ifTrue: [ aDuration ] ifFalse: [ aDuration seconds ].
 ]
 
-{ #category : #'initialize-release' }
+{ #category : #initialization }
 PjBridge >> titleForTest: aTest [
 	^ aTest className , '>>#' , aTest selector
 ]
@@ -687,7 +690,7 @@ PjBridge >> webSocketUrlTag [
 	^self server webSocketUrlTag
 ]
 
-{ #category : #'initialize-release' }
+{ #category : #initialization }
 PjBridge >> websocketDelegateClassName [
 	^self client websocketDelegateClassName
 ]

--- a/Pharo/PharoJsBridge/PjBridgeAppClassDecorator.class.st
+++ b/Pharo/PharoJsBridge/PjBridgeAppClassDecorator.class.st
@@ -77,6 +77,12 @@ PjBridgeAppClassDecorator >> headerLine [
 	^self rawAppClass headerLine
 ]
 
+{ #category : #accessing }
+PjBridgeAppClassDecorator >> pharoJsSelectorPrefix [
+	<pharoJsSkip>
+	^ PjTranspiler pharoJsSelectorPrefix
+]
+
 { #category : #polyfill }
 PjBridgeAppClassDecorator >> polyfill: aPolyfillClass onStream: aStream unlessIn: aSet [
 	self rawAppClass

--- a/Pharo/PharoJsBridge/PjBridgeClient.class.st
+++ b/Pharo/PharoJsBridge/PjBridgeClient.class.st
@@ -86,6 +86,11 @@ PjBridgeClient >> jsGlobalNames [
 			flatCollectAsSet: #classVarNames
 ]
 
+{ #category : #accessing }
+PjBridgeClient >> pharoJsSelectorPrefix [
+	^ exporter transpiler pharoJsSelectorPrefix
+]
+
 { #category : #'initialization-release' }
 PjBridgeClient >> reset [
 	self appClass: self appClass.
@@ -127,7 +132,10 @@ PjBridgeClient >> stop [
 	"stop javascript interpreter"
 	self server isWebSocketConnected ifFalse: [ ^self ].
 	self bridge websocketDelegateClassName ifNil: [ ^self ].
-	self bridge sendMessage: self bridge websocketDelegateClassName, '.', exporter transpiler pharoJsSelectorPrefix, 'terminate()'.
+	[
+		self bridge sendMessage:
+			self bridge websocketDelegateClassName, '.', self pharoJsSelectorPrefix, 'terminate()'
+	] on: ConnectionTimedOut do: [ " nothing: the socket's gone away " ].
 
 ]
 

--- a/Pharo/PharoJsBridge/PjBridgeClient.class.st
+++ b/Pharo/PharoJsBridge/PjBridgeClient.class.st
@@ -127,7 +127,7 @@ PjBridgeClient >> stop [
 	"stop javascript interpreter"
 	self server isWebSocketConnected ifFalse: [ ^self ].
 	self bridge websocketDelegateClassName ifNil: [ ^self ].
-	self bridge sendMessage: self bridge websocketDelegateClassName, '.', PjTranspiler pharoJsSelectorPrefix, 'terminate()'.
+	self bridge sendMessage: self bridge websocketDelegateClassName, '.', exporter transpiler pharoJsSelectorPrefix, 'terminate()'.
 
 ]
 

--- a/Pharo/PharoJsBridge/PjEvaluatorWebsocketDelegate.class.st
+++ b/Pharo/PharoJsBridge/PjEvaluatorWebsocketDelegate.class.st
@@ -51,11 +51,11 @@ PjEvaluatorWebsocketDelegate class >> default: newInstance [
 ]
 
 { #category : #'socket behavior' }
-PjEvaluatorWebsocketDelegate class >> eval_jsGenerator [
+PjEvaluatorWebsocketDelegate class >> eval_jsGenerator: transpiler [
 	<pharoJsSkip>
 	^'var result;
 	try{
-		result = Object.', PjTranspiler pharoJsSelectorPrefix,'resultObject_((function(){return this.eval(aString)})());
+		result = Object.', transpiler pharoJsSelectorPrefix,'resultObject_((function(){return this.eval(aString)})());
 	}catch(exception){
 		result={exception:exception.message};
 	}
@@ -78,7 +78,7 @@ PjEvaluatorWebsocketDelegate class >> initialize [
 ]
 
 { #category : #'socket behavior' }
-PjEvaluatorWebsocketDelegate class >> makeBlockClosureProxy_stopPropagation_jsGenerator [
+PjEvaluatorWebsocketDelegate class >> makeBlockClosureProxy_stopPropagation_jsGenerator: transpiler [
 	<pharoJsSkip>
 	^'
 	var self=this;
@@ -88,9 +88,9 @@ PjEvaluatorWebsocketDelegate class >> makeBlockClosureProxy_stopPropagation_jsGe
 		};
 	function callback(name,ev,jsThis) {
 		if (stop) ev.stopPropagation();
-		self.', PjTranspiler pharoJsSelectorPrefix, 'doCallBack_(JSON.stringify({cb : [name,
-								Object.', PjTranspiler pharoJsSelectorPrefix, 'resultObject_(ev),
-								Object.', PjTranspiler pharoJsSelectorPrefix, 'resultObject_(withThis?jsThis:undefined)]}));
+		self.', transpiler pharoJsSelectorPrefix, 'doCallBack_(JSON.stringify({cb : [name,
+								Object.', transpiler pharoJsSelectorPrefix, 'resultObject_(ev),
+								Object.', transpiler pharoJsSelectorPrefix, 'resultObject_(withThis?jsThis:undefined)]}));
 	}
 	PjBlockClosureProxy.$PjRefCount=0;
 	return PjBlockClosureProxy;
@@ -98,11 +98,11 @@ PjEvaluatorWebsocketDelegate class >> makeBlockClosureProxy_stopPropagation_jsGe
 ]
 
 { #category : #'initialize-release' }
-PjEvaluatorWebsocketDelegate class >> makeInspect_jsGenerator [
+PjEvaluatorWebsocketDelegate class >> makeInspect_jsGenerator: transpiler [
 	<pharoJsSkip>
 	^'var wsd=this;
 	return function(){
-		wsd.', PjTranspiler pharoJsSelectorPrefix, 'doCallBack_(JSON.stringify({inspect:Object.', PjTranspiler pharoJsSelectorPrefix, 'resultObject_(this)}));
+		wsd.', transpiler pharoJsSelectorPrefix, 'doCallBack_(JSON.stringify({inspect:Object.', transpiler pharoJsSelectorPrefix, 'resultObject_(this)}));
 		return this
 	}'
 ]
@@ -192,7 +192,7 @@ PjEvaluatorWebsocketDelegate >> doCallBack: aResult [
 
 { #category : #'socket behavior' }
 PjEvaluatorWebsocketDelegate >> eval: aString [
-	<jsGenerator: #eval_jsGenerator>
+	<jsGenerator: #eval_jsGenerator:>
 ]
 
 { #category : #'initialize-release' }
@@ -219,12 +219,12 @@ PjEvaluatorWebsocketDelegate >> makeBlockClosureProxy: withThis [
 
 { #category : #'socket behavior' }
 PjEvaluatorWebsocketDelegate >> makeBlockClosureProxy: withThis stopPropagation: stop [
-	<jsGenerator: #makeBlockClosureProxy_stopPropagation_jsGenerator>
+	<jsGenerator: #makeBlockClosureProxy_stopPropagation_jsGenerator:>
 ]
 
 { #category : #'initialize-release' }
 PjEvaluatorWebsocketDelegate >> makeInspect [
-	<jsGenerator: #makeInspect_jsGenerator>
+	<jsGenerator: #makeInspect_jsGenerator:>
 ]
 
 { #category : #connecting }

--- a/Pharo/PharoJsBridge/PjProxy.class.st
+++ b/Pharo/PharoJsBridge/PjProxy.class.st
@@ -252,7 +252,7 @@ PjProxy >> printJsOn: aStream [
 PjProxy >> removeEventListener: type [
 	^ self jsBridge: [ : bridge |
 		bridge evalJavascript: bridge websocketDelegateClassName,
-			'.', PjTranspiler pharoJsSelectorPrefix, 'set_callback_to_(',jsName,',',type asJSON,',undefined);'
+			'.', bridge transpiler pharoJsSelectorPrefix, 'set_callback_to_(',jsName,',',type asJSON,',undefined);'
 	]
 ]
 

--- a/Pharo/PharoJsBridgeTest/PjBridgeTestCase.class.st
+++ b/Pharo/PharoJsBridgeTest/PjBridgeTestCase.class.st
@@ -121,3 +121,8 @@ PjBridgeTestCase >> tearDown [
 	Author uniqueInstance fullName: authorInitialName.
 
 ]
+
+{ #category : #'test support' }
+PjBridgeTestCase >> transpileMethod: aMethod [
+	^ self bridge transpiler transpileMethodToString: aMethod
+]

--- a/Pharo/PharoJsBridgeTest/PjInfrastructureTest.class.st
+++ b/Pharo/PharoJsBridgeTest/PjInfrastructureTest.class.st
@@ -14,20 +14,22 @@ PjInfrastructureTest >> testCallGetsTrampolined [
 
 { #category : #testing }
 PjInfrastructureTest >> testDNUSetup [
+	| prefix |
+	prefix := self bridge exporter transpiler pharoJsSelectorPrefix.
 	self
-		assert: (self bridge evalJavascript: 'undefined === document.', PjTranspiler pharoJsSelectorPrefix, 'children').
+		assert: (self bridge evalJavascript: 'undefined === document.', prefix, 'children').
 	self assert: (self bridge evalBlock: [ document children ~= nil ]).
 	self
 		assert:
-			(self bridge evalJavascript: 'window.', PjTranspiler pharoJsSelectorPrefix, 'children !== document.', PjTranspiler pharoJsSelectorPrefix, 'children').
+			(self bridge evalJavascript: 'window.', prefix, 'children !== document.', prefix, 'children').
 	self
-		assert: (self bridge evalJavascript: 'window.', PjTranspiler pharoJsSelectorPrefix, 'children !== undefined').
+		assert: (self bridge evalJavascript: 'window.', prefix, 'children !== undefined').
 	self
-		assert: (self bridge evalJavascript: 'window.', PjTranspiler pharoJsSelectorPrefix, 'children === console.', PjTranspiler pharoJsSelectorPrefix, 'children').
+		assert: (self bridge evalJavascript: 'window.', prefix, 'children === console.', prefix, 'children').
 	self
 		assert:
 			(self bridge
-				evalJavascript: 'HTMLDocument.prototype.', PjTranspiler pharoJsSelectorPrefix, 'children === document.', PjTranspiler pharoJsSelectorPrefix, 'children')
+				evalJavascript: 'HTMLDocument.prototype.', prefix, 'children === document.', prefix, 'children')
 ]
 
 { #category : #testing }
@@ -51,7 +53,7 @@ PjInfrastructureTest >> testIs [
 { #category : #testing }
 PjInfrastructureTest >> testJSSelector [
 	|prefix|
-	prefix := PjTranspiler pharoJsSelectorPrefix.
+	prefix := self bridge exporter transpiler pharoJsSelectorPrefix.
 	self assert: [PjCore makePharoJsSelector: #foo] evaluatesTo: prefix, 'foo'.
 	self assert: [PjCore makePharoJsSelector: #foo:] evaluatesTo: prefix, 'foo_'.
 	self assert: [PjCore makePharoJsSelector: ','] evaluatesTo: prefix, '44_'.

--- a/Pharo/PharoJsBridgeTest/PjLoadForTest.class.st
+++ b/Pharo/PharoJsBridgeTest/PjLoadForTest.class.st
@@ -28,6 +28,12 @@ PjLoadForTest class >> initialize [
 ]
 
 { #category : #any }
+PjLoadForTest class >> literal [
+	<jsLiteralGenerator>
+	^ 'abc','def'
+]
+
+{ #category : #any }
 PjLoadForTest class >> reset [
 	<pharoJsSkip>
 	self initialize
@@ -44,6 +50,12 @@ PjLoadForTest class >> setupClassVars [
 { #category : #any }
 PjLoadForTest class >> y [
 	^ Y
+]
+
+{ #category : #any }
+PjLoadForTest >> literal [
+	<jsLiteralGenerator>
+	^ 3 + 4
 ]
 
 { #category : #any }

--- a/Pharo/PharoJsBridgeTest/PjLoadingTest.class.st
+++ b/Pharo/PharoJsBridgeTest/PjLoadingTest.class.st
@@ -47,6 +47,13 @@ PjLoadingTest >> testEvalBlock [
 ]
 
 { #category : #testing }
+PjLoadingTest >> testLiteralGeneration [
+	self assertEquivalent: [ PjLoadForTest literal ].
+	self assertEquivalent: [ PjLoadForTest new literal ].
+
+]
+
+{ #category : #testing }
 PjLoadingTest >> testLoadClass [
 	PjLoadForTest reset.
 	self bridge loadClass: PjLoadForTest.
@@ -64,7 +71,7 @@ PjLoadingTest >> testLoadClass [
 { #category : #testing }
 PjLoadingTest >> testLoadClassContents [
 	| first firstBlock second secondBlock className third pjPrefix|
-	pjPrefix := PjTranspiler pharoJsSelectorPrefix.
+	pjPrefix := self bridge exporter transpiler pharoJsSelectorPrefix.
 	className := PjLoadForTest nameToUseForJsConversion.
 	PjLoadForTest reset.
 	first := self bridge convertToJs: PjLoadForTest.

--- a/Pharo/PharoJsCoreLibraries/Margin.extension.st
+++ b/Pharo/PharoJsCoreLibraries/Margin.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #Margin }
+
+{ #category : #'*PharoJsCoreLibraries' }
+Margin class >> javascriptPlaceholder [
+	^ PjMargin
+]

--- a/Pharo/PharoJsCoreLibraries/PjBoolean.class.st
+++ b/Pharo/PharoJsCoreLibraries/PjBoolean.class.st
@@ -10,7 +10,7 @@ Class {
 }
 
 { #category : #'class initialization' }
-PjBoolean class >> identityHash_jsGenerator [
+PjBoolean class >> identityHash_jsGenerator: transpiler [
 	<pharoJsSkip>
 	^'if(this == true){
 		return ', true identityHash asString,';}
@@ -66,7 +66,7 @@ PjBoolean >> asString [
 
 { #category : #'not defined category' }
 PjBoolean >> identityHash [
-	<jsGenerator: #identityHash_jsGenerator>
+	<jsGenerator: #identityHash_jsGenerator:>
 ]
 
 { #category : #controlling }

--- a/Pharo/PharoJsCoreLibraries/PjFunction.class.st
+++ b/Pharo/PharoJsCoreLibraries/PjFunction.class.st
@@ -32,12 +32,12 @@ PjFunction class >> jsTranspilationImportMethods [
 ]
 
 { #category : #exceptions }
-PjFunction class >> on_do_jsGenerator [
+PjFunction class >> on_do_jsGenerator: transpiler [
 	<pharoJsSkip>
 	^'try{
 		return this()
 	}catch(ex){
-		if(ex.', PjTranspiler pharoJsSelectorPrefix, 'isKindOf_(exception)){return handlerAction(ex)}
+		if(ex.', transpiler pharoJsSelectorPrefix, 'isKindOf_(exception)){return handlerAction(ex)}
 		throw ex
 	}'
 ]
@@ -186,7 +186,7 @@ PjFunction >> new: arg1 with: arg2 with: arg3 with: arg4 with: arg5 [
 
 { #category : #exceptions }
 PjFunction >> on: exception do: handlerAction [
-	<jsGenerator: #on_do_jsGenerator>
+	<jsGenerator: #on_do_jsGenerator:>
 ]
 
 { #category : #'Behavior: reflection' }

--- a/Pharo/PharoJsCoreLibraries/PjMargin.class.st
+++ b/Pharo/PharoJsCoreLibraries/PjMargin.class.st
@@ -1,0 +1,8 @@
+"
+I am an empty implementation of Margin because Point has an asMargin method we don't support.
+"
+Class {
+	#name : #PjMargin,
+	#superclass : #PjObject,
+	#category : #'PharoJsCoreLibraries-Kernel'
+}

--- a/Pharo/PharoJsCoreLibraries/PjNumber.class.st
+++ b/Pharo/PharoJsCoreLibraries/PjNumber.class.st
@@ -32,9 +32,9 @@ Class {
 }
 
 { #category : #arithmetics }
-PjNumber class >> divide_jsGenerator [
+PjNumber class >> divide_jsGenerator: transpiler [
 	<pharoJsSkip> 
-	^'if(anObject==0) return ZeroDivide.', PjTranspiler pharoJsSelectorPrefix, 'signal();return this / anObject;'
+	^'if(anObject==0) return ZeroDivide.', transpiler pharoJsSelectorPrefix, 'signal();return this / anObject;'
 ]
 
 { #category : #'class initialization' }
@@ -103,7 +103,7 @@ PjNumber >> - anObject [
 
 { #category : #arithmetics }
 PjNumber >> / anObject [
-	<jsGenerator: #divide_jsGenerator>
+	<jsGenerator: #divide_jsGenerator:>
 ]
 
 { #category : #arithmetics }

--- a/Pharo/PharoJsCoreLibraries/PjObject.class.st
+++ b/Pharo/PharoJsCoreLibraries/PjObject.class.st
@@ -30,9 +30,9 @@ PjObject class >> addDnuSupportFor: selector [
 ]
 
 { #category : #reflection }
-PjObject class >> allEnumeratableKeysDo_jsGenerator [
+PjObject class >> allEnumeratableKeysDo_jsGenerator: transpiler [
 	<pharoJsSkip>
-	^'for (var i in this){aBlock.', PjTranspiler pharoJsSelectorPrefix, 'value_(i)};
+	^'for (var i in this){aBlock.', transpiler pharoJsSelectorPrefix, 'value_(i)};
 	return this;'
 ]
 
@@ -62,16 +62,16 @@ PjObject class >> jsTranspilationImportMethods [
 ]
 
 { #category : #'dictionary emulation' }
-PjObject class >> keysAndValuesDo_jsGenerator [
+PjObject class >> keysAndValuesDo_jsGenerator: transpiler [
 	<pharoJsSkip>
-	^'for (var i in this){if(this.hasOwnProperty(i))aBlock.', PjTranspiler pharoJsSelectorPrefix, 'value_value_(i,this[i])};
+	^'for (var i in this){if(this.hasOwnProperty(i))aBlock.', transpiler pharoJsSelectorPrefix, 'value_value_(i,this[i])};
 	return this;'
 ]
 
 { #category : #'dictionary emulation' }
-PjObject class >> keysDo_jsGenerator [
+PjObject class >> keysDo_jsGenerator: transpiler [
 	<pharoJsSkip>
-	^'for (var i in this){if(this.hasOwnProperty(i))aBlock.', PjTranspiler pharoJsSelectorPrefix, 'value_(i)};
+	^'for (var i in this){if(this.hasOwnProperty(i))aBlock.', transpiler pharoJsSelectorPrefix, 'value_(i)};
 	return this;'
 ]
 
@@ -82,21 +82,21 @@ PjObject class >> nextIdentityHash [
 
 { #category : #proxy }
 PjObject class >> resultObject: result [
-	<jsGenerator: #resultObject_jsGenerator>
+	<jsGenerator: #resultObject_jsGenerator:>
 	
 ]
 
 { #category : #proxy }
-PjObject class >> resultObject_jsGenerator [
+PjObject class >> resultObject_jsGenerator: transpiler [
 	<pharoJsSkip>
-	^'if (result != undefined) return result.', PjTranspiler pharoJsSelectorPrefix, 'proxyResponse();
+	^'if (result != undefined) return result.', transpiler pharoJsSelectorPrefix, 'proxyResponse();
 		return null;'
 ]
 
 { #category : #'dictionary emulation' }
-PjObject class >> valuesDo_jsGenerator [
+PjObject class >> valuesDo_jsGenerator: transpiler [
 	<pharoJsSkip>
-	^'for (var i in this){if(this.hasOwnProperty(i))aBlock.', PjTranspiler pharoJsSelectorPrefix, 'value_(this[i])};
+	^'for (var i in this){if(this.hasOwnProperty(i))aBlock.', transpiler pharoJsSelectorPrefix, 'value_(this[i])};
 	return this;'
 ]
 
@@ -132,7 +132,7 @@ PjObject >> allEnumeratableKeys [
 
 { #category : #reflection }
 PjObject >> allEnumeratableKeysDo: aBlock [
-	<jsGenerator: #allEnumeratableKeysDo_jsGenerator>
+	<jsGenerator: #allEnumeratableKeysDo_jsGenerator:>
 ]
 
 { #category : #converting }
@@ -264,12 +264,12 @@ PjObject >> keys [
 
 { #category : #'dictionary emulation' }
 PjObject >> keysAndValuesDo: aBlock [
-	<jsGenerator: #keysAndValuesDo_jsGenerator>
+	<jsGenerator: #keysAndValuesDo_jsGenerator:>
 ]
 
 { #category : #'dictionary emulation' }
 PjObject >> keysDo: aBlock [
-	<jsGenerator: #keysDo_jsGenerator>
+	<jsGenerator: #keysDo_jsGenerator:>
 ]
 
 { #category : #'message performing' }
@@ -394,7 +394,7 @@ PjObject >> value [
 
 { #category : #'dictionary emulation' }
 PjObject >> valuesDo: aBlock [
-	<jsGenerator: #valuesDo_jsGenerator>
+	<jsGenerator: #valuesDo_jsGenerator:>
 ]
 
 { #category : #accessing }

--- a/Pharo/PharoJsCoreLibraries/PjReadWriteStream.class.st
+++ b/Pharo/PharoJsCoreLibraries/PjReadWriteStream.class.st
@@ -29,13 +29,14 @@ PjReadWriteStream class >> jsTranspilationImportMethods [
 
 { #category : #accessing }
 PjReadWriteStream >> atEnd [
-	position >= readLimit ifTrue: [ 1 < array size ifTrue: [self contents] ].
+	position >= readLimit ifTrue: [ self contents ].
 	^ position >= readLimit
 ]
 
 { #category : #accessing }
 PjReadWriteStream >> contents [
-	^self load: self join
+	1 < array size ifTrue: [ self load: self join ].
+	^ collection
 ]
 
 { #category : #'initialize-release' }

--- a/Pharo/PharoJsCoreLibraries/PjRectangle.class.st
+++ b/Pharo/PharoJsCoreLibraries/PjRectangle.class.st
@@ -1,3 +1,6 @@
+"
+I am a minimal implementation of Rectangle, just so Point can create me.
+"
 Class {
 	#name : #PjRectangle,
 	#superclass : #PjObject,

--- a/Pharo/PharoJsCoreLibraries/PjStack.class.st
+++ b/Pharo/PharoJsCoreLibraries/PjStack.class.st
@@ -1,10 +1,10 @@
+"
+I am a minimal implementation of Stack
+"
 Class {
 	#name : #PjStack,
-	#superclass : #Array,
+	#superclass : #PjArray,
 	#type : #variable,
-	#pools : [
-		'PjUniversalGlobals'
-	],
 	#category : #'PharoJsCoreLibraries-Kernel'
 }
 

--- a/Pharo/PharoJsCoreLibraries/PjString.class.st
+++ b/Pharo/PharoJsCoreLibraries/PjString.class.st
@@ -28,6 +28,9 @@ PjString class >> jsTranspilationImportMethods [
 			String -> #(
 				findTokens: 
 			).
+			Symbol -> #(
+				cull: value: 
+			).
 			Character class -> #(
 				cr escape lf linefeed space tab
 			).

--- a/Pharo/PharoJsCoreLibraries/PjTArray.trait.st
+++ b/Pharo/PharoJsCoreLibraries/PjTArray.trait.st
@@ -9,19 +9,19 @@ Trait {
 }
 
 { #category : #enumerating }
-PjTArray classSide >> collect_jsGenerator [
+PjTArray classSide >> collect_jsGenerator: transpiler [
 	<pharoJsSkip> 
-	^'var result=[];for(var i=0,max=this.length;i<max;++i)result.push(typeof aBlock=="string"?$asNil$(this[i]).', PjTranspiler pharoJsSelectorPrefix, 'perform_(aBlock):aBlock(this[i]));return result'
+	^'var result=[];for(var i=0,max=this.length;i<max;++i)result.push(typeof aBlock=="string"?$asNil$(this[i]).', transpiler pharoJsSelectorPrefix, 'perform_(aBlock):aBlock(this[i]));return result'
 ]
 
 { #category : #testing }
-PjTArray classSide >> includes_jsGenerator [
+PjTArray classSide >> includes_jsGenerator: transpiler [
 	<pharoJsSkip>
-	^'if (x.', PjTranspiler pharoJsSelectorPrefix, 'isJSPrimitiveType()) {
+	^'if (x.', transpiler pharoJsSelectorPrefix, 'isJSPrimitiveType()) {
 		if (this.includes(x)) return true;
 		for(var i=this.length-1;i>=0;--i) if (x==this[i]) return true;
 		return false}		
-	for(var i=this.length-1;i>=0;--i) if (x.', PjTranspiler pharoJsSelectorPrefix, '61_(this[i])) return true;
+	for(var i=this.length-1;i>=0;--i) if (x.', transpiler pharoJsSelectorPrefix, '61_(this[i])) return true;
 	return false'
 ]
 
@@ -50,9 +50,9 @@ PjTArray classSide >> jsTranspilationImportMethodsArray [
 ]
 
 { #category : #enumerating }
-PjTArray classSide >> select_jsGenerator [
+PjTArray classSide >> select_jsGenerator: transpiler [
 	<pharoJsSkip> 
-	^'var result=[];for(var i=0,max=this.length;i<max;++i){if(true==(typeof aBlock=="string"?$asNil$(this[i]).', PjTranspiler pharoJsSelectorPrefix, 'perform_(aBlock):aBlock(this[i])))result.push(this[i])}return result'
+	^'var result=[];for(var i=0,max=this.length;i<max;++i){if(true==(typeof aBlock=="string"?$asNil$(this[i]).', transpiler pharoJsSelectorPrefix, 'perform_(aBlock):aBlock(this[i])))result.push(this[i])}return result'
 ]
 
 { #category : #copying }
@@ -94,7 +94,7 @@ PjTArray >> at: index ifAbsent: aBlock [
 
 { #category : #enumerating }
 PjTArray >> collect: aBlock [
-	<jsGenerator: #collect_jsGenerator>
+	<jsGenerator: #collect_jsGenerator:>
 ]
 
 { #category : #enumerating }
@@ -120,7 +120,7 @@ PjTArray >> ifEmpty: aBlock [
 
 { #category : #testing }
 PjTArray >> includes: x [
-	<jsGenerator: #includes_jsGenerator>
+	<jsGenerator: #includes_jsGenerator:>
 ]
 
 { #category : #accessing }
@@ -155,7 +155,7 @@ PjTArray >> second [
 
 { #category : #enumerating }
 PjTArray >> select: aBlock [
-	<jsGenerator: #select_jsGenerator>
+	<jsGenerator: #select_jsGenerator:>
 ]
 
 { #category : #enumerating }

--- a/Pharo/PharoJsCoreLibraries/PjTCollection.trait.st
+++ b/Pharo/PharoJsCoreLibraries/PjTCollection.trait.st
@@ -9,10 +9,10 @@ Trait {
 }
 
 { #category : #random }
-PjTCollection classSide >> atRandom_jsGenerator [
+PjTCollection classSide >> atRandom_jsGenerator: transpiler [
 	<pharoJsSkip>
-	^'var randomIndex = Math.floor((Math.random() * this.', PjTranspiler pharoJsSelectorPrefix, 'size()) + 1);
-	return this.', PjTranspiler pharoJsSelectorPrefix, 'at_(randomIndex);'
+	^'var randomIndex = Math.floor((Math.random() * this.', transpiler pharoJsSelectorPrefix, 'size()) + 1);
+	return this.', transpiler pharoJsSelectorPrefix, 'at_(randomIndex);'
 ]
 
 { #category : #'pharojs support' }
@@ -39,5 +39,5 @@ PjTCollection >> = aMagnitude [
 
 { #category : #random }
 PjTCollection >> atRandom [
-	<jsGenerator: #atRandom_jsGenerator>
+	<jsGenerator: #atRandom_jsGenerator:>
 ]

--- a/Pharo/PharoJsCoreLibraries/PjUndefinedObject.class.st
+++ b/Pharo/PharoJsCoreLibraries/PjUndefinedObject.class.st
@@ -8,7 +8,7 @@ Class {
 }
 
 { #category : #initialize }
-PjUndefinedObject class >> identityHash_jsGenerator [
+PjUndefinedObject class >> identityHash_jsGenerator: transpiler [
 	<pharoJsSkip>
 	^'return ', nil identityHash asString
 ]
@@ -51,7 +51,7 @@ PjUndefinedObject >> asJSON [
 
 { #category : #'not defined category' }
 PjUndefinedObject >> identityHash [
-	<jsGenerator: #identityHash_jsGenerator>
+	<jsGenerator: #identityHash_jsGenerator:>
 ]
 
 { #category : #accessing }

--- a/Pharo/PharoJsCoreLibraries/Symbol.extension.st
+++ b/Pharo/PharoJsCoreLibraries/Symbol.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #Symbol }
+
+{ #category : #'*PharoJsCoreLibraries' }
+Symbol class >> javascriptPlaceholder [
+	^ PjString
+]

--- a/Pharo/PharoJsCoreLibrariesTest/PjCoreLibrariesTranspilationTest.class.st
+++ b/Pharo/PharoJsCoreLibrariesTest/PjCoreLibrariesTranspilationTest.class.st
@@ -15,6 +15,6 @@ PjCoreLibrariesTranspilationTest >> testPjStringClass [
 PjCoreLibrariesTranspilationTest >> testPjUndefinedObjectClass [
 	self jsCode: (self convertClass: PjUndefinedObject).
 	self assertInstanceMethod: #= equals:  '(other){return undefined==other}'.
-	self assertClassMethod: #new equals: '(){return Smalltalk.', PjTranspiler pharoJsSelectorPrefix, 'signal_("cannot create instances of UndefinedObject")}'.
-	self assertClassMethod: #javascriptInitialize equals: '(){Smalltalk.', PjTranspiler pharoJsSelectorPrefix, 'nilInJs_(this.', PjTranspiler pharoJsSelectorPrefix, 'basicNew());return this}'
+	self assertClassMethod: #new equals: '(){return Smalltalk.', transpiler pharoJsSelectorPrefix, 'signal_("cannot create instances of UndefinedObject")}'.
+	self assertClassMethod: #javascriptInitialize equals: '(){Smalltalk.', transpiler pharoJsSelectorPrefix, 'nilInJs_(this.', transpiler pharoJsSelectorPrefix, 'basicNew());return this}'
 ]

--- a/Pharo/PharoJsExporter/ManifestPharoJsExporter.class.st
+++ b/Pharo/PharoJsExporter/ManifestPharoJsExporter.class.st
@@ -1,0 +1,18 @@
+"
+I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+"
+Class {
+	#name : #ManifestPharoJsExporter,
+	#superclass : #PackageManifest,
+	#category : #'PharoJsExporter-Manifest'
+}
+
+{ #category : #'code-critics' }
+ManifestPharoJsExporter class >> ruleGRGuradGuardClauseRuleV1FalsePositive [
+	^ #(#(#(#RGMethodDefinition #(#PjDependentTranspiler #addClassToConvert: #false)) #'2020-02-14T08:19:48.428313-05:00') )
+]
+
+{ #category : #'code-critics' }
+ManifestPharoJsExporter class >> ruleRBGuardingClauseRuleV1FalsePositive [
+	^ #(#(#(#RGMethodDefinition #(#PjDependentTranspiler #addClassToConvert: #false)) #'2020-02-14T08:19:35.789312-05:00') )
+]

--- a/Pharo/PharoJsExporter/PjDependentTranspiler.class.st
+++ b/Pharo/PharoJsExporter/PjDependentTranspiler.class.st
@@ -24,9 +24,14 @@ PjDependentTranspiler class >> lineEnding [
 
 { #category : #transpiling }
 PjDependentTranspiler >> addClassToConvert: aClass [
+	| addClass |
 	aClass javascriptIsExportableClass ifFalse: [ ^ converter transpilationError: 'non-exportable class ',aClass name,' referenced' ].
-	classesToConvert add: aClass classToUseForJsConversion.
-
+	addClass := aClass classToUseForJsConversion.
+	(classesToConvert includes: addClass) ifFalse: [
+		" redundant test allows setting breakpoint for adding classes "
+		addClass == PjTranspiler  ifTrue: [ self halt ].
+		classesToConvert add: addClass.
+	]
 ]
 
 { #category : #transpiling }

--- a/Pharo/PharoJsExporter/PjDependentTranspilerTest.class.st
+++ b/Pharo/PharoJsExporter/PjDependentTranspilerTest.class.st
@@ -31,7 +31,7 @@ PjDependentTranspilerTest >> testIncludeMethods [
 	self generateJsCodeForClasses: { PjClassForTranspilationTest }.
 	self assert: (self instanceMethod: #selector) equals: '(){return this.selector}'.
 	self assert: (self instanceMethod: #selectors) equals: '(){return [this.selector]}'.
-	self assert: (self instanceMethod: #order:selector:) equals: '(aNumber,aString){this.', PjTranspiler pharoJsSelectorPrefix, 'order_(aNumber);this.selector=aString;return this}'.
+	self assert: (self instanceMethod: #order:selector:) equals: '(aNumber,aString){this.', transpiler pharoJsSelectorPrefix, 'order_(aNumber);this.selector=aString;return this}'.
 	self assert: (self classMethod: #javascriptInitialize) equals: '(){this.pj_instVarNamed_put_("stackTraceLimit",100);return this}'.
 	self assert: (self classMethod: #javascriptName) equals: nil. "because of pragma"
 	self assert: (self classMethod: #exampleForTest) equals: '(){return this}'.

--- a/Pharo/PharoJsExporter/PjExporter.class.st
+++ b/Pharo/PharoJsExporter/PjExporter.class.st
@@ -243,7 +243,7 @@ PjExporter >> writeCoreObject [
 		nextPutAll: '})';cr;
 		nextPutAll: coreName;
 		nextPut: $.;
-		nextPutAll: PjTranspiler pharoJsSelectorPrefix;
+		nextPutAll: transpiler pharoJsSelectorPrefix;
 		nextPutAll: 'initializeCore();';cr
 ]
 

--- a/Pharo/PharoJsExporter/PjExporter.class.st
+++ b/Pharo/PharoJsExporter/PjExporter.class.st
@@ -71,6 +71,7 @@ PjExporter >> appClass [
 { #category : #accessing }
 PjExporter >> appClass: aClass [ 
 	appClass := aClass.
+	transpiler pharoJsSelectorPrefix: aClass pharoJsSelectorPrefix.
 	self addAllClasses: appClass appClasses.
 	self addAllPackages: appClass appPackages.
 

--- a/Pharo/PharoJsExporter/PjExporterTest.class.st
+++ b/Pharo/PharoJsExporter/PjExporterTest.class.st
@@ -25,6 +25,16 @@ PjExporterTest >> lineEnding [
 	^exporter transpiler lineEnding
 ]
 
+{ #category : #accessing }
+PjExporterTest >> pharoJsSelectorPrefix [
+	^ exporter transpiler pharoJsSelectorPrefix
+]
+
+{ #category : #'as yet unclassified' }
+PjExporterTest >> selectorsPrefix [
+	^ exporter transpiler pharoJsSelectorPrefix
+]
+
 { #category : #running }
 PjExporterTest >> setUp [
 	super setUp.
@@ -38,7 +48,7 @@ PjExporterTest >> testAvoidOverridingOnImportMethodsFromPharo [
 	exporter addClass: PjClassExtensionForTest.
 	jsCode := exporter javascriptCode.
 	self assertInstanceMethod: #isLiteral equals: '(){return 42}'.
-	self assert: (jsCode splitOn: 'i$(function ', PjTranspiler pharoJsSelectorPrefix,'isLiteral') size equals: 2.
+	self assert: (jsCode splitOn: 'i$(function ', exporter transpiler pharoJsSelectorPrefix,'isLiteral') size equals: 2.
 
 ]
 
@@ -46,13 +56,13 @@ PjExporterTest >> testAvoidOverridingOnImportMethodsFromPharo [
 PjExporterTest >> testClassInheritanceOrder [
 	exporter appClass: PjApplication.
 	jsCode := exporter javascriptCode.
-	self assert: 'Object.', PjTranspiler pharoJsSelectorPrefix, 'subclass_(Error)' precedes: 'Error.', PjTranspiler pharoJsSelectorPrefix, 'subclass_'
+	self assert: 'Object.', exporter transpiler pharoJsSelectorPrefix, 'subclass_(Error)' precedes: 'Error.', exporter transpiler pharoJsSelectorPrefix, 'subclass_'
 ]
 
 { #category : #testing }
 PjExporterTest >> testCoreClassedLoaded [
 	|pjPrefix|
-	pjPrefix := PjTranspiler pharoJsSelectorPrefix.
+	pjPrefix := exporter transpiler pharoJsSelectorPrefix.
 	exporter appClass: PjApplication.
 	jsCode := exporter javascriptCode.
 	self assert: (jsCode includesSubstring: 'Object.', pjPrefix, 'subclass_("PjApplication")' ).

--- a/Pharo/PharoJsExporter/PjExporterTest.class.st
+++ b/Pharo/PharoJsExporter/PjExporterTest.class.st
@@ -10,7 +10,7 @@ Class {
 	#category : #'PharoJsExporter-Tests'
 }
 
-{ #category : #accessing }
+{ #category : #running }
 PjExporterTest >> classToTranspile [
 	^ PjClassExtensionForTest
 ]
@@ -95,6 +95,14 @@ PjExporterTest >> testImportMethodsFromPharo [
 	#(allInstances allInstancesDo: new) do: [ : selector |
 		self assertHasClassMethod: selector ].
 	self assertInstanceMethod: #yourself equals: '(){return this}'
+]
+
+{ #category : #testing }
+PjExporterTest >> testJsSelector [
+	| contents |
+	contents := (PjTestFileExporter exportApp: PjTestClassForPolyfill) contents.
+	self assert: (contents includesSubstring: 'function alt_m(').
+
 ]
 
 { #category : #testing }

--- a/Pharo/PharoJsExporter/PjTestClassForPolyfill.class.st
+++ b/Pharo/PharoJsExporter/PjTestClassForPolyfill.class.st
@@ -7,6 +7,11 @@ Class {
 	#category : #'PharoJsExporter-Tests-Support'
 }
 
+{ #category : #accessing }
+PjTestClassForPolyfill class >> pharoJsSelectorPrefix [
+	^ 'alt_'
+]
+
 { #category : #any }
 PjTestClassForPolyfill >> m [
 	| bar ws |

--- a/Pharo/PharoJsTiming/PjRbObject.class.st
+++ b/Pharo/PharoJsTiming/PjRbObject.class.st
@@ -28,9 +28,9 @@ PjRbObject class >> initialize [
 ]
 
 { #category : #transcript }
-PjRbObject class >> show_jsGenerator [
+PjRbObject class >> show_jsGenerator: transpiler [
 	<pharoJsSkip> 
-	^'console.log(aString.', PjTranspiler pharoJsSelectorPrefix, 'asString())'
+	^'console.log(aString.', transpiler pharoJsSelectorPrefix, 'asString())'
 ]
 
 { #category : #utilities }
@@ -53,6 +53,6 @@ PjRbObject >> cr [
 
 { #category : #transcript }
 PjRbObject >> show: aString [
-	<jsGenerator: #show_jsGenerator>
+	<jsGenerator: #show_jsGenerator:>
 	Transcript show: aString
 ]

--- a/Pharo/PharoJsTiming/PjTimingTest.class.st
+++ b/Pharo/PharoJsTiming/PjTimingTest.class.st
@@ -109,7 +109,7 @@ PjTimingTest >> assert: aBlock isFasterThan: bBlock with: someOptimizations [
 		PjUnparsedStringNode string: nullBlock.
 		PjUnparsedStringNode string: noOptim.
 		PjUnparsedStringNode string: optim }) .
-"	results := bridge evalJavascript: 'global.PjTimingPlatformApp.', PjTranspiler pharoJsSelectorPrefix, 'timeNull_nonOptimized_optimized_(', nullBlock,',', noOptim,',', optim,')'.
+"	results := bridge evalJavascript: 'global.PjTimingPlatformApp.', transpiler pharoJsSelectorPrefix, 'timeNull_nonOptimized_optimized_(', nullBlock,',', noOptim,',', optim,')'.
 "	self assert: (self class ratio: results betterThan:  1.2 for: self)
 ]
 

--- a/Pharo/PharoJsTranspiler/BlockClosure.extension.st
+++ b/Pharo/PharoJsTranspiler/BlockClosure.extension.st
@@ -95,7 +95,7 @@ BlockClosure >> isClosed [
 ]
 
 { #category : #'*PharoJsTranspiler' }
-BlockClosure >> isLiteralJavascriptValue [
+BlockClosure >> isFreeJavascriptValue [
 	^ self isClosed
 ]
 

--- a/Pharo/PharoJsTranspiler/Class.extension.st
+++ b/Pharo/PharoJsTranspiler/Class.extension.st
@@ -29,7 +29,7 @@ Class >> hasJavascriptName [
 ]
 
 { #category : #'*PharoJsTranspiler' }
-Class >> isLiteralJavascriptValue [
+Class >> isFreeJavascriptValue [
 	^ true
 ]
 
@@ -50,4 +50,9 @@ Class >> needsClassDefinition [
 { #category : #'*PharoJsTranspiler' }
 Class >> needsInitialization [
 	^(self hasClassMethod: #initialize) or: [ self hasClassMethod: #javascriptInitialize ]
+]
+
+{ #category : #'*PharoJsTranspiler' }
+Class >> printJsOn: aStream [
+	self error: 'Class doesn''t have a literal representation'
 ]

--- a/Pharo/PharoJsTranspiler/Dictionary.extension.st
+++ b/Pharo/PharoJsTranspiler/Dictionary.extension.st
@@ -1,6 +1,14 @@
 Extension { #name : #Dictionary }
 
 { #category : #'*PharoJsTranspiler' }
+Dictionary >> isFreeJavascriptValue [
+	self keysAndValuesDo: [ : key : value |
+		key isString ifFalse: [ ^ false ] .
+		value isFreeJavascriptValue ifFalse: [ ^ false ] ].
+	^ true
+]
+
+{ #category : #'*PharoJsTranspiler' }
 Dictionary >> isLiteralJavascriptValue [
 	self keysAndValuesDo: [ : key : value |
 		key isString ifFalse: [ ^ false ] .

--- a/Pharo/PharoJsTranspiler/Object.extension.st
+++ b/Pharo/PharoJsTranspiler/Object.extension.st
@@ -21,6 +21,11 @@ Object >> convertToJsUsing: aPjTranspiler [
 ]
 
 { #category : #'*PharoJsTranspiler' }
+Object >> isFreeJavascriptValue [
+	^ self isLiteralJavascriptValue
+]
+
+{ #category : #'*PharoJsTranspiler' }
 Object >> isLiteralJavascriptValue [
 	^ false
 ]

--- a/Pharo/PharoJsTranspiler/PjApplication.extension.st
+++ b/Pharo/PharoJsTranspiler/PjApplication.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #PjApplication }
+
+{ #category : #'*PharoJsTranspiler' }
+PjApplication class >> pharoJsSelectorPrefix [
+	<pharoJsSkip>
+	^ PjTranspiler pharoJsSelectorPrefix
+]

--- a/Pharo/PharoJsTranspiler/PjApplication.extension.st
+++ b/Pharo/PharoJsTranspiler/PjApplication.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : #PjApplication }
-
-{ #category : #'*PharoJsTranspiler' }
-PjApplication class >> pharoJsSelectorPrefix [
-	<pharoJsSkip>
-	^ PjTranspiler pharoJsSelectorPrefix
-]

--- a/Pharo/PharoJsTranspiler/PjAstConverter.class.st
+++ b/Pharo/PharoJsTranspiler/PjAstConverter.class.st
@@ -44,6 +44,14 @@ PjAstConverter class >> jsCodePragmaKeyword [
 
 ]
 
+{ #category : #accessing }
+PjAstConverter class >> jsLiteralGeneratorPragmaKeyword [
+	"The argument of the pragma is a selector for class side message that generates javascript code that is used as the body of the method.
+	The smalltalk code if any is simply ignored."
+	^#jsLiteralGenerator
+
+]
+
 { #category : #conversions }
 PjAstConverter >> addAllConversions: aCollection [
 	messageConverter addAllConversions: aCollection
@@ -158,7 +166,7 @@ PjAstConverter >> handleJsCodeGeneratorPragmaInMethodNode: aRBMethodNode [
 		pragmaNamed: self jsCodeGeneratorPragmaKeyword.
 	generatorSelector := jsGeneratorPragma arguments first.
 	jsCode := classForConversion instanceSide
-		perform: generatorSelector value.
+		perform: generatorSelector value with: transpiler.
 	^ self astForJsCode: jsCode
 ]
 
@@ -170,6 +178,24 @@ PjAstConverter >> handleJsCodePragmaInMethodNode: aRBMethodNode [
 	^self astForJsCode: jsCode
 ]
 
+{ #category : #'as yet unclassified' }
+PjAstConverter >> handleJsLiteralGeneratorPragmaInMethodNode: aRBMethodNode [ 
+	| jsCode forClass selector result |
+	forClass := aRBMethodNode scope outerScope outerScope getClass.
+	selector := aRBMethodNode selector.
+	jsCode := String streamContents: [: s |
+		s nextPutAll: 'return '.
+		result := forClass isMeta ifTrue: [
+				forClass instanceSide perform: selector
+			] ifFalse: [
+				forClass basicNew perform: selector
+			].
+		result isLiteralJavascriptValue ifFalse: [ PjJavascriptTranspilationError signal: forClass asString,'>>#',selector,' returns a value with no literal Javascript representation'].
+		result printJsOn: s.
+	].
+	^ self astForJsCode: jsCode
+]
+
 { #category : #visiting }
 PjAstConverter >> handlePragmaInMethodNode: aRBMethodNode [
 	| body |
@@ -177,6 +203,8 @@ PjAstConverter >> handlePragmaInMethodNode: aRBMethodNode [
 		ifTrue: [ ^self handleJsCodePragmaInMethodNode: aRBMethodNode ].
 	(aRBMethodNode hasPragmaNamed: self jsCodeGeneratorPragmaKeyword)
 		ifTrue: [ ^self handleJsCodeGeneratorPragmaInMethodNode: aRBMethodNode ].
+	(aRBMethodNode hasPragmaNamed: self jsLiteralGeneratorPragmaKeyword)
+		ifTrue: [ ^self handleJsLiteralGeneratorPragmaInMethodNode: aRBMethodNode ].
 	pushingReturnClass := nil.	"PjReturnNode"
 	needSelfReturn := false.
 	(methodPrimitive ~= 0
@@ -284,6 +312,11 @@ PjAstConverter >> jsCodeGeneratorPragmaKeyword [
 { #category : #accessing }
 PjAstConverter >> jsCodePragmaKeyword [
 	^self class jsCodePragmaKeyword
+]
+
+{ #category : #'as yet unclassified' }
+PjAstConverter >> jsLiteralGeneratorPragmaKeyword [
+	^ self class jsLiteralGeneratorPragmaKeyword
 ]
 
 { #category : #accessing }

--- a/Pharo/PharoJsTranspiler/PjAstConverter.class.st
+++ b/Pharo/PharoJsTranspiler/PjAstConverter.class.st
@@ -210,7 +210,7 @@ PjAstConverter >> handlePragmaInMethodNode: aRBMethodNode [
 	(methodPrimitive ~= 0
 		and: [ methodPrimitive ~= 256 and: [ aRBMethodNode statements isEmpty ] ])
 		ifTrue: [ PjJavascriptTranspilationError
-				signal: 'primitive method with no fallback code' ].
+				signal: 'primitive method with no fallback code: ', aRBMethodNode selector ].
 	body := self visitAllNodes: aRBMethodNode statements.
 	(needSelfReturn
 		and: [ body isEmpty or: [ body expressions last isReturnOrThrow not ] ])

--- a/Pharo/PharoJsTranspiler/PjBlockClosureAnalyser.class.st
+++ b/Pharo/PharoJsTranspiler/PjBlockClosureAnalyser.class.st
@@ -35,7 +35,7 @@ PjBlockClosureAnalyser >> checkFree: aRBVariableNode [
 	name := aRBVariableNode name.
 	self externalVariables at: name ifPresent: [ : value |
 		(value isKindOf: Error) ifTrue: [ value signal ].
-		value isLiteralJavascriptValue ifFalse: [ PjJavascriptTranspilationError signal: 'reference to non-literal value in variable: ', name ].
+		value isFreeJavascriptValue ifFalse: [ PjJavascriptTranspilationError signal: 'reference to non-literal value in variable: ', name ].
 		self register: name with: value.
 		^ PjTempVariableNode identifier: name
 	].

--- a/Pharo/PharoJsTranspiler/PjBlockTranspilationTest.class.st
+++ b/Pharo/PharoJsTranspiler/PjBlockTranspilationTest.class.st
@@ -174,7 +174,7 @@ PjBlockTranspilationTest >> testBlockWithReferencedScopes [
 	x := 1337.
 	self 
 		assertStBlock: [|w| w := superClosed value.{w.x. 123}] asClosedBlock
-		convertsTo: '(function(superClosed,x){return function(){var w;w=$asNil$(superClosed).', PjTranspiler pharoJsSelectorPrefix, 'value();return [w,x,123]}})((function(y){return function(){return y}})(17),1337)'.
+		convertsTo: '(function(superClosed,x){return function(){var w;w=$asNil$(superClosed).', transpiler pharoJsSelectorPrefix, 'value();return [w,x,123]}})((function(y){return function(){return y}})(17),1337)'.
 
 ]
 

--- a/Pharo/PharoJsTranspiler/PjClassDefinitionTranspilationTest.class.st
+++ b/Pharo/PharoJsTranspiler/PjClassDefinitionTranspilationTest.class.st
@@ -16,6 +16,6 @@ PjClassDefinitionTranspilationTest >> expectedClassName [
 
 { #category : #testing }
 PjClassDefinitionTranspilationTest >> testClassDefinedAsConstructor [
-	self assert: self jsCode includes: 'Object.', PjTranspiler pharoJsSelectorPrefix, 'subclass_("',className, '");'.
+	self assert: self jsCode includes: 'Object.', transpiler pharoJsSelectorPrefix, 'subclass_("',className, '");'.
 
 ]

--- a/Pharo/PharoJsTranspiler/PjClassExtensionTranspilationTest.class.st
+++ b/Pharo/PharoJsTranspiler/PjClassExtensionTranspilationTest.class.st
@@ -23,6 +23,6 @@ PjClassExtensionTranspilationTest >> testClassExtension [
 { #category : #testing }
 PjClassExtensionTranspilationTest >> testJavascriptInitialize [
 	self assertClassMethod: #javascriptInitialize equals: '(){return this}'.
-	self assert: self jsCode includes: PjClassForTranspilationTest name, '.', PjTranspiler pharoJsSelectorPrefix, 'javascriptInitialize()'.
+	self assert: self jsCode includes: PjClassForTranspilationTest name, '.', transpiler pharoJsSelectorPrefix, 'javascriptInitialize()'.
 
 ]

--- a/Pharo/PharoJsTranspiler/PjClassForDefinitionTest.class.st
+++ b/Pharo/PharoJsTranspiler/PjClassForDefinitionTest.class.st
@@ -3,3 +3,15 @@ Class {
 	#superclass : #Object,
 	#category : #'PharoJsTranspiler-Tests-Support'
 }
+
+{ #category : #accessing }
+PjClassForDefinitionTest class >> literal [
+	<jsLiteralGenerator>
+	^ 'abc','def'
+]
+
+{ #category : #accessing }
+PjClassForDefinitionTest >> literal [
+	<jsLiteralGenerator>
+	^ 3 + 4
+]

--- a/Pharo/PharoJsTranspiler/PjClassForTranspilationTest.class.st
+++ b/Pharo/PharoJsTranspiler/PjClassForTranspilationTest.class.st
@@ -35,7 +35,7 @@ PjClassForTranspilationTest class >> c2 [
 ]
 
 { #category : #'pharojs support' }
-PjClassForTranspilationTest class >> classMethodJsGenerator [
+PjClassForTranspilationTest class >> classMethod_jsGenerator: transpiler [
 	<pharoJsSkip>
 	^self name asJSON
 ]
@@ -54,7 +54,7 @@ PjClassForTranspilationTest class >> initialize [
 ]
 
 { #category : #'pharojs support' }
-PjClassForTranspilationTest class >> instanceMethodJsGenerator [
+PjClassForTranspilationTest class >> instanceMethod_jsGenerator: transpiler [
 	<pharoJsSkip>
 	^'return 1', ' + ', '2;'
 ]
@@ -93,7 +93,7 @@ PjClassForTranspilationTest class >> m1 [
 
 { #category : #any }
 PjClassForTranspilationTest class >> methodWithJsGenerator [
-	<jsGenerator: #classMethodJsGenerator>
+	<jsGenerator: #classMethod_jsGenerator:>
 ]
 
 { #category : #any }
@@ -147,8 +147,8 @@ PjClassForTranspilationTest >> composedCalls [
 ]
 
 { #category : #any }
-PjClassForTranspilationTest >> insanceMethodWithJsGenerator [
-		<jsGenerator: #instanceMethodJsGenerator>
+PjClassForTranspilationTest >> instanceMethodWithJsGenerator [
+		<jsGenerator: #instanceMethod_jsGenerator:>
 	^self
 ]
 

--- a/Pharo/PharoJsTranspiler/PjClassVariableNode.class.st
+++ b/Pharo/PharoJsTranspiler/PjClassVariableNode.class.st
@@ -38,5 +38,5 @@ PjClassVariableNode >> poolReference: aString [
 
 { #category : #converting }
 PjClassVariableNode >> poolReferenceWith: aPjTranspiler [ 
-	^ aPjTranspiler poolReference: poolReference for: myClass instanceSide
+	^ aPjTranspiler poolReference: poolReference for: myClass
 ]

--- a/Pharo/PharoJsTranspiler/PjCore.class.st
+++ b/Pharo/PharoJsTranspiler/PjCore.class.st
@@ -199,16 +199,16 @@ PjCore class >> javascriptName [
 
 { #category : #'reflection support' }
 PjCore class >> keys: anObject [
-	<jsGenerator: #keys_jsGenerator>
+	<jsGenerator: #keys_jsGenerator:>
 ]
 
 { #category : #'reflection support' }
-PjCore class >> keys_jsGenerator [
+PjCore class >> keys_jsGenerator: transpiler [
 	<pharoJsSkip>
 	^'
 	var result={};
-	for (var i in anObject) { if(typeof anObject[i]!="function" && anObject[i]!=null && anObject[i].', PjTranspiler pharoJsSelectorPrefix, 'proxyResponse) result[i]=anObject[i].', PjTranspiler pharoJsSelectorPrefix, 'proxyResponse()}
-	return {', PjTranspiler pharoJsSelectorPrefix, 'proxyResponse:function(){return {keys:result}}}
+	for (var i in anObject) { if(typeof anObject[i]!="function" && anObject[i]!=null && anObject[i].', transpiler pharoJsSelectorPrefix, 'proxyResponse) result[i]=anObject[i].', transpiler pharoJsSelectorPrefix, 'proxyResponse()}
+	return {', transpiler pharoJsSelectorPrefix, 'proxyResponse:function(){return {keys:result}}}
 	'
 ]
 
@@ -219,14 +219,14 @@ PjCore class >> log: message [
 
 { #category : #'doesNotUnderstand support' }
 PjCore class >> makeDNU: aSelector [
-	<jsGenerator: #makeDNU_jsGenerator>
+	<jsGenerator: #makeDNU_jsGenerator:>
 ]
 
 { #category : #'doesNotUnderstand support' }
-PjCore class >> makeDNU_jsGenerator [
+PjCore class >> makeDNU_jsGenerator: transpiler [
 	<pharoJsSkip>
 	|prefix|
-	prefix := PjTranspiler pharoJsSelectorPrefix.
+	prefix := transpiler pharoJsSelectorPrefix.
 	^'var pjCore=this,ss=this.', prefix, 'makeSmalltalkSelector_(aSelector);
 	switch (ss.split(":").length) {
 		case 1: return function __DNU(){
@@ -330,17 +330,17 @@ PjCore class >> metaclassClass: anObject [
 
 { #category : #'reflection support' }
 PjCore class >> metaclassOf: aClass [
-	<jsGenerator: #metaclassOf_jsGenerator>
+	<jsGenerator: #metaclassOf_jsGenerator:>
 ]
 
 { #category : #'reflection support' }
-PjCore class >> metaclassOf_jsGenerator [
+PjCore class >> metaclassOf_jsGenerator: transpiler [
 	<pharoJsSkip>
-	^'if(this.metaclassClass!==this) return this.metaclassClass.', PjTranspiler pharoJsSelectorPrefix, 'metaclassOf_(aClass);
+	^'if(this.metaclassClass!==this) return this.metaclassClass.', transpiler pharoJsSelectorPrefix, 'metaclassOf_(aClass);
 	var theMetaClass={ prototype: aClass.__proto__,__proto__:this.theClassClass.prototype,
-		', PjTranspiler pharoJsSelectorPrefix, 'name: function(){return aClass.', PjTranspiler pharoJsSelectorPrefix, 'name()+" class"},
-		', PjTranspiler pharoJsSelectorPrefix, 'theNonMetaClass: function(){return aClass},
-		', PjTranspiler pharoJsSelectorPrefix, 'theMetaClass: function(){return theMetaClass},
+		', transpiler pharoJsSelectorPrefix, 'name: function(){return aClass.', transpiler pharoJsSelectorPrefix, 'name()+" class"},
+		', transpiler pharoJsSelectorPrefix, 'theNonMetaClass: function(){return aClass},
+		', transpiler pharoJsSelectorPrefix, 'theMetaClass: function(){return theMetaClass},
 		};
 	return theMetaClass
 	'
@@ -366,14 +366,13 @@ PjCore class >> nilTestFunctionName [
 
 { #category : #accessing }
 PjCore class >> pharoJsSelectorPrefix [
-	<jsGenerator: #pharoJsSelectorPrefix_jsGenerator>
+	<jsGenerator: #pharoJsSelectorPrefix_jsGenerator:>
 	^ PjTranspiler pharoJsSelectorPrefix
 ]
 
 { #category : #accessing }
-PjCore class >> pharoJsSelectorPrefix_jsGenerator [
-	<pharoJsSkip>
-	^ 'return ', PjTranspiler pharoJsSelectorPrefix asJSON
+PjCore class >> pharoJsSelectorPrefix_jsGenerator: transpiler [
+	^ 'return ',transpiler pharoJsSelectorPrefix asJSON
 ]
 
 { #category : #'doesNotUnderstand support' }
@@ -407,34 +406,34 @@ PjCore class >> registerDnuForAll: anArray [
 
 { #category : #'doesNotUnderstand support' }
 PjCore class >> selector: selector arguments: args [
-	<jsGenerator: #selector_arguments_jsGenerator>
+	<jsGenerator: #selector_arguments_jsGenerator:>
 
 ]
 
 { #category : #'doesNotUnderstand support' }
-PjCore class >> selector_arguments_jsGenerator [
+PjCore class >> selector_arguments_jsGenerator: transpiler [
 	<pharoJsSkip>
 	^'if(this.messageClass!==this)
-		return this.messageClass.', PjTranspiler pharoJsSelectorPrefix, 'selector_arguments_(selector,arguments);
+		return this.messageClass.', transpiler pharoJsSelectorPrefix, 'selector_arguments_(selector,arguments);
 	return {
 			selector: selector,
-			', PjTranspiler pharoJsSelectorPrefix, 'selector: function(){return this.selector},
+			', transpiler pharoJsSelectorPrefix, 'selector: function(){return this.selector},
 			arguments: args,
-			', PjTranspiler pharoJsSelectorPrefix, 'arguments: function(){return this.arguments}
+			', transpiler pharoJsSelectorPrefix, 'arguments: function(){return this.arguments}
 		}'
 
 ]
 
 { #category : #'reflection support' }
 PjCore class >> subclassSelector [
-	<jsGenerator: #subclassSelector_jsGenerator>
+	<jsGenerator: #subclassSelector_jsGenerator:>
 
 ]
 
 { #category : #'reflection support' }
-PjCore class >> subclassSelector_jsGenerator [
+PjCore class >> subclassSelector_jsGenerator: transpiler [
 	<pharoJsSkip>
-	^'return ', (PjCore pharoJsSelectorPrefix, #subclass_) asJSON
+	^'return ', (transpiler pharoJsSelectorPrefix, #subclass_) asJSON
 ]
 
 { #category : #'throw support' }

--- a/Pharo/PharoJsTranspiler/PjCore.class.st
+++ b/Pharo/PharoJsTranspiler/PjCore.class.st
@@ -367,7 +367,7 @@ PjCore class >> nilTestFunctionName [
 { #category : #accessing }
 PjCore class >> pharoJsSelectorPrefix [
 	<jsGenerator: #pharoJsSelectorPrefix_jsGenerator:>
-	^ PjTranspiler pharoJsSelectorPrefix
+	^ self error: 'Only for Javascript side'
 ]
 
 { #category : #accessing }

--- a/Pharo/PharoJsTranspiler/PjCoreTranspilationTest.class.st
+++ b/Pharo/PharoJsTranspiler/PjCoreTranspilationTest.class.st
@@ -24,7 +24,7 @@ PjCoreTranspilationTest >> testOptimizedJsAt [
 	| method asNil |
 	asNil := PjStringGenerator nilTestFunctionName.
 	method := self classMethod: #makePharoJsSelector:.
-	self assert: (method indexOfSubCollection: asNil,'(aSelector[0]).', PjTranspiler pharoJsSelectorPrefix, '61_(') > 0.
-	self assert: (method indexOfSubCollection: asNil ,'(this.selectorCache.hasOwnProperty(aSelector)).', PjTranspiler pharoJsSelectorPrefix, 'ifTrue_(') > 0.
+	self assert: (method indexOfSubCollection: asNil,'(aSelector[0]).', transpiler pharoJsSelectorPrefix, '61_(') > 0.
+	self assert: (method indexOfSubCollection: asNil ,'(this.selectorCache.hasOwnProperty(aSelector)).', transpiler pharoJsSelectorPrefix, 'ifTrue_(') > 0.
 
 ]

--- a/Pharo/PharoJsTranspiler/PjLiteralGeneratorTranspilationTest.class.st
+++ b/Pharo/PharoJsTranspiler/PjLiteralGeneratorTranspilationTest.class.st
@@ -1,0 +1,19 @@
+Class {
+	#name : #PjLiteralGeneratorTranspilationTest,
+	#superclass : #PjSingleClassTranspilationTest,
+	#category : #'PharoJsTranspiler-Tests'
+}
+
+{ #category : #accessing }
+PjLiteralGeneratorTranspilationTest >> classToTranspile [
+	^ PjClassForDefinitionTest
+]
+
+{ #category : #testing }
+PjLiteralGeneratorTranspilationTest >> testLiteralGeneratrion [
+	| pjPrefix |
+	pjPrefix := transpiler pharoJsSelectorPrefix.
+	self assert: self jsCode includes: 'i$(function ',pjPrefix,'literal(){return 7}'.
+	self assert: self jsCode includes: 'c$(function ',pjPrefix,'literal(){return "abcdef"}'.
+
+]

--- a/Pharo/PharoJsTranspiler/PjPackageTranspilationTest.class.st
+++ b/Pharo/PharoJsTranspiler/PjPackageTranspilationTest.class.st
@@ -34,12 +34,12 @@ PjPackageTranspilationTest >> assert: firstClass inCodeWithPrefix: codeString be
 
 { #category : #testing }
 PjPackageTranspilationTest >> assert: firstClass initializedBefore: lastClass [
-	self assert: firstClass inCodeWith: '.', PjTranspiler pharoJsSelectorPrefix, 'initialize();' before: lastClass.
+	self assert: firstClass inCodeWith: '.', transpiler pharoJsSelectorPrefix, 'initialize();' before: lastClass.
 ]
 
 { #category : #testing }
 PjPackageTranspilationTest >> assert: firstClass protoSetBefore: lastClass [
-	self assert: firstClass inCodeWithPrefix: '.', PjTranspiler pharoJsSelectorPrefix, 'subclass_("' before: lastClass.
+	self assert: firstClass inCodeWithPrefix: '.', transpiler pharoJsSelectorPrefix, 'subclass_("' before: lastClass.
 
 ]
 
@@ -91,11 +91,11 @@ PjPackageTranspilationTest >> testJavascriptInitializeOverridesClassInitialize [
 	PjClientForJavascriptInitializationTest.
 	PjProviderForInitializationTest
 	}.
-	self assert: self jsCode includes: PjClientForJavascriptInitializationTest name, '.', PjTranspiler pharoJsSelectorPrefix, 'javascriptInitialize()'.
-	self deny: self jsCode includes: PjClientForJavascriptInitializationTest name, '.', PjTranspiler pharoJsSelectorPrefix, 'initialize()'.
+	self assert: self jsCode includes: PjClientForJavascriptInitializationTest name, '.', transpiler pharoJsSelectorPrefix, 'javascriptInitialize()'.
+	self deny: self jsCode includes: PjClientForJavascriptInitializationTest name, '.', transpiler pharoJsSelectorPrefix, 'initialize()'.
 	self 
-		assert: PjProviderForInitializationTest name, '.', PjTranspiler pharoJsSelectorPrefix, 'initialize()'
-		appearsBefore: PjClientForJavascriptInitializationTest name, '.', PjTranspiler pharoJsSelectorPrefix, 'javascriptInitialize()'
+		assert: PjProviderForInitializationTest name, '.', transpiler pharoJsSelectorPrefix, 'initialize()'
+		appearsBefore: PjClientForJavascriptInitializationTest name, '.', transpiler pharoJsSelectorPrefix, 'javascriptInitialize()'
 ]
 
 { #category : #testing }

--- a/Pharo/PharoJsTranspiler/PjPackageTranspilationTest.class.st
+++ b/Pharo/PharoJsTranspiler/PjPackageTranspilationTest.class.st
@@ -68,7 +68,7 @@ PjPackageTranspilationTest >> testDnuSetup [
 	self generateJsCodeForClasses: {
 	PjClassBForCircularTranspilationTest.
 	}.
-	self assert: self jsCode includes: '.', PjTranspiler pharoJsSelectorPrefix, 'registerDnuForAll_(["isNil","javascriptName"]);'
+	self assert: self jsCode includes: '.', self selectorsPrefix, 'registerDnuForAll_(["isNil","javascriptName"]);'
 ]
 
 { #category : #testing }
@@ -79,7 +79,7 @@ PjPackageTranspilationTest >> testDuplicateClasses [
 	self generateJsCodeForClasses: classesToConvert.
 	className := PjClassAForPackageTranspilationTest name.
 	classDefintionString := 'subclass_("', className,'")'.
-	classInitializationString := className, '.', PjTranspiler pharoJsSelectorPrefix, 'initialize();'.
+	classInitializationString := className, '.', self selectorsPrefix, 'initialize();'.
 	{classDefintionString. classInitializationString} do: [:each |
 		self assert: (jsCode allRangesOfSubstring: each) size equals: 1] .
 

--- a/Pharo/PharoJsTranspiler/PjPrefixForTranspilationTest.class.st
+++ b/Pharo/PharoJsTranspiler/PjPrefixForTranspilationTest.class.st
@@ -1,0 +1,24 @@
+Class {
+	#name : #PjPrefixForTranspilationTest,
+	#superclass : #PjSingleClassTranspilationTest,
+	#category : #'PharoJsTranspiler-Tests'
+}
+
+{ #category : #accessing }
+PjPrefixForTranspilationTest >> classToTranspile [
+	^ PjClassForDefinitionTest
+]
+
+{ #category : #testing }
+PjPrefixForTranspilationTest >> selectorsPrefix [
+	^ 'altPrefix_'
+]
+
+{ #category : #testing }
+PjPrefixForTranspilationTest >> testPrefix [
+	| pjPrefix |
+	pjPrefix := self selectorsPrefix.
+	self assert: self jsCode includes: 'i$(function ',pjPrefix,'literal(){'.
+	self assert: self jsCode includes: 'c$(function ',pjPrefix,'literal(){'.
+
+]

--- a/Pharo/PharoJsTranspiler/PjPrimitiveTranspilationTest.class.st
+++ b/Pharo/PharoJsTranspiler/PjPrimitiveTranspilationTest.class.st
@@ -19,5 +19,5 @@ PjPrimitiveTranspilationTest >> testPrimitiveWithFallback [
 	self generateJsCodeForClasses: {
 		PjClassForPrimitiveTest.
 	}.
-	self assertInstanceMethod: #+ equals: '(aNumber){return $asNil$(aNumber).',PjTranspiler pharoJsSelectorPrefix ,'adaptToFloat_andSend_(this,"+")}'
+	self assertInstanceMethod: #+ equals: '(aNumber){return $asNil$(aNumber).',transpiler pharoJsSelectorPrefix ,'adaptToFloat_andSend_(this,"+")}'
 ]

--- a/Pharo/PharoJsTranspiler/PjReplacedClassTranspilationTest.class.st
+++ b/Pharo/PharoJsTranspiler/PjReplacedClassTranspilationTest.class.st
@@ -15,7 +15,7 @@ PjReplacedClassTranspilationTest >> classToTranspile [
 { #category : #testing }
 PjReplacedClassTranspilationTest >> testClassReplacement [
 	| prefix |
-	prefix := PjTranspiler pharoJsSelectorPrefix.
+	prefix := transpiler pharoJsSelectorPrefix.
 	self deny: self jsCode includes: 'function ', className, '(){}'.
 "We use defineProperty. See PjTranspiler>>#writeMethodsOf:named:with:"
 	self assert: self jsCode includes: prefix, 'add_and_(op1,op2){return op2}'.

--- a/Pharo/PharoJsTranspiler/PjSingleClassTranspilationTest.class.st
+++ b/Pharo/PharoJsTranspiler/PjSingleClassTranspilationTest.class.st
@@ -21,6 +21,7 @@ PjSingleClassTranspilationTest >> expectedClassName [
 PjSingleClassTranspilationTest >> setUp [
 	super setUp.
 	transpiler poolFor: self classToTranspile.
+	transpiler pharoJsSelectorPrefix: self selectorsPrefix.
 	self jsCode: (self convertClass: self classToTranspile).
 	className := self expectedClassName
 ]
@@ -33,7 +34,7 @@ PjSingleClassTranspilationTest >> testBlockReferencingSelf [
 { #category : #testing }
 PjSingleClassTranspilationTest >> testCascade [
 	| prefix |
-	prefix := PjTranspiler pharoJsSelectorPrefix.
+	prefix := self selectorsPrefix.
 	self assertInstanceMethod: #cascadeSelf equals: '(){return (this.', prefix, 'm1(),this.', prefix, 'm_(4),this.', prefix, 'yourself())}'.
 	self assertInstanceMethod: #cascadeSuper equals: '(){return (',self classToTranspile superclass name,'.prototype.', prefix, 'isNil.call(this),',self classToTranspile superclass name,'.prototype.', prefix, 'yourself.call(this))}'.
 	self assertInstanceMethod: #cascade: equals: '(x){var $1;return ($1=$asNil$($asNil$(x).', prefix, 'foo()),$1.', prefix, 'bar(),$1.', prefix, 'yourself())}'.
@@ -72,16 +73,16 @@ PjSingleClassTranspilationTest >> testClassSideMethods [
 		superclassName,'.S=',superclassName,'.S;',
 		sharedPoolName,'.C=',sharedPoolName,'.C;',
 		'return this}'.
-	self assert: (self jsCode endsWith: className, '.', PjTranspiler pharoJsSelectorPrefix, 'initialize();').
+	self assert: (self jsCode endsWith: className, '.', self selectorsPrefix, 'initialize();').
 	self assertClassMethod: #javascriptName equals: nil.
-	self assertClassMethod: #methodWithJsGenerator equals: '(){', self classToTranspile classMethodJsGenerator,'}'
+	self assertClassMethod: #methodWithJsGenerator equals: '(){', (self classToTranspile classMethod_jsGenerator: transpiler),'}'
 
 ]
 
 { #category : #testing }
 PjSingleClassTranspilationTest >> testCompose [
 	| prefix |
-	prefix := PjTranspiler pharoJsSelectorPrefix.
+	prefix := self selectorsPrefix.
 	self assertInstanceMethod: #composedCalls equals: '(){return $asNil$($asNil$(this.', prefix, 'm1()).', prefix, 'm_(4)).', prefix, 'm2()}'.
 
 ]
@@ -102,7 +103,7 @@ PjSingleClassTranspilationTest >> testInstanceSideMethods [
 	self deny: self jsCode includes: 'methodToSkip'.
 	self deny: self jsCode includes: 'ThisShouldBeSkipped'.
 	self assertInstanceMethod: #m: equals: '($in){console.log("abc")}'.
-	self assertInstanceMethod: #insanceMethodWithJsGenerator equals:  '(){', self classToTranspile instanceMethodJsGenerator, '}'.
+	self assertInstanceMethod: #instanceMethodWithJsGenerator equals:  '(){', (self classToTranspile instanceMethod_jsGenerator: transpiler), '}'.
 
 ]
 
@@ -120,5 +121,5 @@ PjSingleClassTranspilationTest >> testNative [
 
 { #category : #testing }
 PjSingleClassTranspilationTest >> testToDoExpr [
-	self assertInstanceMethod: #toDoWithObjectAsParameter equals: '(){(1).', PjTranspiler pharoJsSelectorPrefix, 'to_do_(10,Object);return this}'
+	self assertInstanceMethod: #toDoWithObjectAsParameter equals: '(){(1).', self selectorsPrefix, 'to_do_(10,Object);return this}'
 ]

--- a/Pharo/PharoJsTranspiler/PjStringGenerationTest.class.st
+++ b/Pharo/PharoJsTranspiler/PjStringGenerationTest.class.st
@@ -25,13 +25,18 @@ PjStringGenerationTest >> nilTestFunctionName [
 	^PjStringGenerator nilTestFunctionName
 ]
 
+{ #category : #accessing }
+PjStringGenerationTest >> selectorsPrefix [
+	^ PjTranspiler pharoJsSelectorPrefix
+]
+
 { #category : #testing }
 PjStringGenerationTest >> testArray [
 	| x |
 	x := PjTempVariableNode identifier: #x.
 	self
 		assert: (PjArrayNode expressions: { one. two. self apply: x selector: #foo })
-		asStringEquals: '[1,2,$asNil$(x).', PjTranspiler pharoJsSelectorPrefix, 'foo()]'.
+		asStringEquals: '[1,2,$asNil$(x).', self selectorsPrefix, 'foo()]'.
 
 ]
 
@@ -52,7 +57,7 @@ PjStringGenerationTest >> testBlock [
 PjStringGenerationTest >> testClassCall [
 	self
 		assert: (self apply: (PjClassNode identifier: #Number) selector: #one)
-		asStringEquals: 'Number.', PjTranspiler pharoJsSelectorPrefix, 'one()'
+		asStringEquals: 'Number.', self selectorsPrefix, 'one()'
 ]
 
 { #category : #testing }
@@ -82,7 +87,7 @@ PjStringGenerationTest >> testClassVariables [
 { #category : #testing }
 PjStringGenerationTest >> testField [
 	| x bar prefix |
-	prefix := PjTranspiler pharoJsSelectorPrefix.
+	prefix := self selectorsPrefix.
 	x := PjTempVariableNode identifier: #x.
 	bar := PjMessageSelectorNode identifier: #bar.
 	self
@@ -111,7 +116,7 @@ PjStringGenerationTest >> testField [
 { #category : #testing }
 PjStringGenerationTest >> testFieldForCall [
 	| x prefix |
-	prefix := PjTranspiler pharoJsSelectorPrefix.
+	prefix := self selectorsPrefix.
 	x := PjTempVariableNode identifier: #x.
 	self
 		assert: (self apply: selfNode selector: #foo) 
@@ -146,7 +151,7 @@ PjStringGenerationTest >> testFieldForCall [
 PjStringGenerationTest >> testGlobalCall [
 	self
 		assert: (self apply: (PjGlobalNode identifier: #Number) selector: #one)
-		asStringEquals: self nilTestFunctionName,'(Number).', PjTranspiler pharoJsSelectorPrefix, 'one()'
+		asStringEquals: self nilTestFunctionName,'(Number).', self selectorsPrefix, 'one()'
 ]
 
 { #category : #testing }
@@ -166,7 +171,7 @@ xようこそy',(String with: (Character value:257)) ) asStringEquals: '"\000a\\
 { #category : #testing }
 PjStringGenerationTest >> testMethod [
 	| prefix |
-	prefix := PjTranspiler pharoJsSelectorPrefix.
+	prefix := self selectorsPrefix.
 	self
 		assert:
 			(PjMethodNode
@@ -325,20 +330,20 @@ PjStringGenerationTest >> testSelf [
 	self assert: selfNode asStringEquals: 'this'.
 	self
 		assert: (self apply: (PjSelfNode myClass: Integer) selector: #value)
-		asStringEquals: 'this.', PjTranspiler pharoJsSelectorPrefix, 'value()'.
+		asStringEquals: 'this.', self selectorsPrefix, 'value()'.
 	self
 		assert: (self apply: (PjSelfNode inBlock: true) selector: #value)
-		asStringEquals: PjStringGenerator selfName,'.', PjTranspiler pharoJsSelectorPrefix, 'value()'
+		asStringEquals: PjStringGenerator selfName,'.', self selectorsPrefix, 'value()'
 ]
 
 { #category : #testing }
 PjStringGenerationTest >> testSuperCall [
 	self
 		assert: (self apply: (PjSuperNode myClass: Integer) selector: #value)
-		asStringEquals: 'Number.prototype.', PjTranspiler pharoJsSelectorPrefix, 'value.call(this)'.
+		asStringEquals: 'Number.prototype.', self selectorsPrefix, 'value.call(this)'.
 	self
 		assert: (self apply: ((PjSuperNode myClass: Integer class) inBlock: true) selector: #value)
-		asStringEquals: 'Number.', PjTranspiler pharoJsSelectorPrefix, 'value.call(',PjStringGenerator selfName,')'
+		asStringEquals: 'Number.', self selectorsPrefix, 'value.call(',PjStringGenerator selfName,')'
 ]
 
 { #category : #testing }

--- a/Pharo/PharoJsTranspiler/PjStringGenerationTest.class.st
+++ b/Pharo/PharoJsTranspiler/PjStringGenerationTest.class.st
@@ -298,7 +298,7 @@ PjStringGenerationTest >> testReservedWords [
 		assert: (PjClassNode identifier: #for )
 		asStringEquals: 'for'.
 	self
-		assert: (PjClassVariableNode identifier: #prototype )
+		assert: ((PjClassVariableNode identifier: #prototype) myClass: self class)
 		asStringEquals: 'cp$.$prototype'.
 	self
 		assert: (PjClassVariableNode identifier: #for )

--- a/Pharo/PharoJsTranspiler/PjStringGenerator.class.st
+++ b/Pharo/PharoJsTranspiler/PjStringGenerator.class.st
@@ -171,7 +171,7 @@ PjStringGenerator class >> transpilerClass [
 
 { #category : #public }
 PjStringGenerator >> asString: aPjAST [
-	pharoJsSelectorPrefix := PjTranspiler pharoJsSelectorPrefix.
+	pharoJsSelectorPrefix := self selectorsPrefix.
 	^ String
 		streamContents: [ :aStream | self asString: aPjAST on: aStream with: self ]
 ]
@@ -247,7 +247,7 @@ PjStringGenerator >> poolReference: anUndefinedObject for: aClass [
 
 { #category : #'as yet unclassified' }
 PjStringGenerator >> selectorsPrefix [
-	^ transpiler pharoJsSelectorPrefix
+	^ (transpiler ifNil: [PjTranspiler]) pharoJsSelectorPrefix
 ]
 
 { #category : #visiting }

--- a/Pharo/PharoJsTranspiler/PjStringGenerator.class.st
+++ b/Pharo/PharoJsTranspiler/PjStringGenerator.class.st
@@ -63,7 +63,8 @@ Class {
 		'wroteCloseBrace',
 		'currentClass',
 		'currentlyDoingAssignment',
-		'transpiler'
+		'transpiler',
+		'pharoJsSelectorPrefix'
 	],
 	#classVars : [
 		'AssignmentPrecedence',
@@ -170,6 +171,7 @@ PjStringGenerator class >> transpilerClass [
 
 { #category : #public }
 PjStringGenerator >> asString: aPjAST [
+	pharoJsSelectorPrefix := PjTranspiler pharoJsSelectorPrefix.
 	^ String
 		streamContents: [ :aStream | self asString: aPjAST on: aStream with: self ]
 ]
@@ -179,8 +181,8 @@ PjStringGenerator >> asString: aPjAST on: aStream with: aPjTranspiler [
 	jsStream := aStream.
 	currentPrecedenceLevel := -1.
 	currentlyDoingAssignment := false.
-	aPjAST acceptVisitor: self.
 	transpiler := aPjTranspiler.
+	aPjAST acceptVisitor: self.
 
 ]
 
@@ -233,9 +235,19 @@ PjStringGenerator >> nonLocalReturnVariableName [
 	^ self class nonLocalReturnVariableName
 ]
 
+{ #category : #accessing }
+PjStringGenerator >> pharoJsSelectorPrefix [
+	^ pharoJsSelectorPrefix ifNil: [pharoJsSelectorPrefix := transpiler pharoJsSelectorPrefix]
+]
+
+{ #category : #accessing }
+PjStringGenerator >> poolReference: anUndefinedObject for: aClass [ 
+	^ 'cp$'
+]
+
 { #category : #'as yet unclassified' }
 PjStringGenerator >> selectorsPrefix [
-	^PjTranspiler pharoJsSelectorPrefix
+	^ transpiler pharoJsSelectorPrefix
 ]
 
 { #category : #visiting }

--- a/Pharo/PharoJsTranspiler/PjStringWithBlockTranspilationTest.class.st
+++ b/Pharo/PharoJsTranspiler/PjStringWithBlockTranspilationTest.class.st
@@ -29,7 +29,7 @@ PjStringWithBlockTranspilationTest >> testBlock1Arg [
 PjStringWithBlockTranspilationTest >> testBlockAsArgument [
 	self 
 		assertStCode: '1 to: 10 by: 2 do: [: x | x ]' 
-		convertedIncludes: '(1).', 	PjTranspiler pharoJsSelectorPrefix, 'to_by_do_(10,2,function(x){return x})'
+		convertedIncludes: '(1).', 	transpiler pharoJsSelectorPrefix, 'to_by_do_(10,2,function(x){return x})'
 ]
 
 { #category : #testing }

--- a/Pharo/PharoJsTranspiler/PjTStreamWriter.trait.st
+++ b/Pharo/PharoJsTranspiler/PjTStreamWriter.trait.st
@@ -41,11 +41,6 @@ PjTStreamWriter >> nextPutAll: string [
 	self jsStream nextPutAll: string
 ]
 
-{ #category : #writing }
-PjTStreamWriter >> pharoJsSelectorPrefix [
-	^PjTranspiler pharoJsSelectorPrefix
-]
-
 { #category : #'writing low-level' }
 PjTStreamWriter >> print: anObject [
 	anObject printJsOn: self jsStream

--- a/Pharo/PharoJsTranspiler/PjTranspilationTest.class.st
+++ b/Pharo/PharoJsTranspiler/PjTranspilationTest.class.st
@@ -61,7 +61,7 @@ PjTranspilationTest >> nilTestFunctionName [
 
 { #category : #accessing }
 PjTranspilationTest >> selectorsPrefix [
-	^PjTranspiler pharoJsSelectorPrefix
+	^ transpiler pharoJsSelectorPrefix
 ]
 
 { #category : #running }
@@ -81,7 +81,7 @@ PjTranspilationTest >> writeJsSelector: aSelector onStream: aStream [
 	(aSelector beginsWith: self jsNativePrefix) ifTrue: [ 
 			^ aStream nextPutAll: ((aSelector keywords first allButFirst: self jsNativePrefix size) copyWithout: $:) ].
 	isBinary := aSelector isBinary.
-	aStream nextPutAll: self pharoJsSelectorPrefix.
+	aStream nextPutAll: self selectorsPrefix.
 	aSelector do:[ :each | 
 			self writeSelectorChar: each on: aStream isInBinarySelector: isBinary ]
 ]

--- a/Pharo/PharoJsTranspiler/PjTranspiler.class.st
+++ b/Pharo/PharoJsTranspiler/PjTranspiler.class.st
@@ -20,9 +20,7 @@ Class {
 		'writtenDNUs',
 		'beforeCodeOutputHook',
 		'shouldWriteDnu',
-		'poolsUsed'
-	],
-	#classInstVars : [
+		'poolsUsed',
 		'pharoJsSelectorPrefix'
 	],
 	#category : #'PharoJsTranspiler-Kernel'
@@ -48,11 +46,6 @@ PjTranspiler class >> defaultPharoJsSelectorPrefix [
 	^'pj_'
 ]
 
-{ #category : #'class initialization' }
-PjTranspiler class >> initialize [
-	self pharoJsSelectorPrefix: self defaultPharoJsSelectorPrefix
-]
-
 { #category : #accessing }
 PjTranspiler class >> lineEnding [
 	^Character cr
@@ -60,12 +53,7 @@ PjTranspiler class >> lineEnding [
 
 { #category : #transpiling }
 PjTranspiler class >> pharoJsSelectorPrefix [
-	^pharoJsSelectorPrefix
-]
-
-{ #category : #transpiling }
-PjTranspiler class >> pharoJsSelectorPrefix: newSelectorsPrefix [
-	pharoJsSelectorPrefix := newSelectorsPrefix
+	^ self defaultPharoJsSelectorPrefix
 ]
 
 { #category : #accessing }
@@ -290,7 +278,7 @@ PjTranspiler >> initialize [
 	writtenDNUs := Set new.
 	poolsUsed := IdentityDictionary new.
 	classesReferencingCache := IdentityDictionary new.
-
+	self pharoJsSelectorPrefix: self class defaultPharoJsSelectorPrefix
 ]
 
 { #category : #accessing }
@@ -386,6 +374,17 @@ PjTranspiler >> orderForWriting: classes [
 ]
 
 { #category : #transpiling }
+PjTranspiler >> pharoJsSelectorPrefix [
+	^ pharoJsSelectorPrefix
+]
+
+{ #category : #transpiling }
+PjTranspiler >> pharoJsSelectorPrefix: newSelectorsPrefix [
+	pharoJsSelectorPrefix := newSelectorsPrefix.
+
+]
+
+{ #category : #transpiling }
 PjTranspiler >> poolFor: myClass [
 	^ poolsUsed at: myClass ifAbsentPut: [OrderedCollection with: myClass]
 ]
@@ -393,11 +392,15 @@ PjTranspiler >> poolFor: myClass [
 { #category : #transpiling }
 PjTranspiler >> poolReference: aClass for: myClass [
 	| index pool |
-	pool := self poolFor: myClass.
-	(pool includes: aClass) ifFalse: [
-		pool add: aClass
+	myClass ifNil: [
+		index := 0
+	] ifNotNil: [
+		pool := self poolFor: myClass instanceSide.
+		(pool includes: aClass) ifFalse: [
+			pool add: aClass
+		].
+		index := pool indexOf: aClass.
 	].
-	index := pool indexOf: aClass.
 	^ index < 2 ifTrue: [
 			'cp$'
 		] ifFalse: [
@@ -412,7 +415,7 @@ PjTranspiler >> removeAllConversions: aCollection [
 
 { #category : #accessing }
 PjTranspiler >> selectorsPrefix [
-	^PjTranspiler pharoJsSelectorPrefix
+	^ self pharoJsSelectorPrefix
 ]
 
 { #category : #conversions }
@@ -456,6 +459,11 @@ PjTranspiler >> transpileMethod: aMethod [
 		convertAst: aMethod ast
 		withPrimitive: aMethod primitive.
 	generator asString: jsAst on: self jsStream with: self
+]
+
+{ #category : #transpiling }
+PjTranspiler >> transpileMethodToString: aMethod [
+	^ self onTempStreamDo: [ self transpileMethod: aMethod ]
 ]
 
 { #category : #transpiling }
@@ -528,7 +536,7 @@ PjTranspiler >> writeDnuList [
 	self 
 		writeNameForClass: self coreClass;
 		nextPut: $.;
-		nextPutAll: PjTranspiler pharoJsSelectorPrefix;
+		nextPutAll: self pharoJsSelectorPrefix;
 		nextPutAll: 'registerDnuForAll_(['.
 	selectors do: [
 		: selector |

--- a/Pharo/PharoJsTranspiler/SequenceableCollection.extension.st
+++ b/Pharo/PharoJsTranspiler/SequenceableCollection.extension.st
@@ -9,10 +9,13 @@ SequenceableCollection >> includes: seq1 before: seq2 [
 ]
 
 { #category : #'*PharoJsTranspiler' }
+SequenceableCollection >> isFreeJavascriptValue [
+	^ self allSatisfy: #isFreeJavascriptValue
+]
+
+{ #category : #'*PharoJsTranspiler' }
 SequenceableCollection >> isLiteralJavascriptValue [
-	self do: [ : each |
-		each isLiteralJavascriptValue ifFalse: [ ^ false ] ].
-	^ true
+	^ self allSatisfy: #isLiteralJavascriptValue
 ]
 
 { #category : #'*PharoJsTranspiler' }

--- a/Pharo/PharoJsTranspiler/String.extension.st
+++ b/Pharo/PharoJsTranspiler/String.extension.st
@@ -1,11 +1,6 @@
 Extension { #name : #String }
 
 { #category : #'*PharoJsTranspiler' }
-String >> basicConvertToJsUsing: transpiler [
-	^transpiler basicConvertString: self
-]
-
-{ #category : #'*PharoJsTranspiler' }
 String >> isLiteralJavascriptValue [
 	^ true
 ]

--- a/Pharo/PharoJsTranspilerOptimization/PjGenerationOptimizationTest.class.st
+++ b/Pharo/PharoJsTranspilerOptimization/PjGenerationOptimizationTest.class.st
@@ -15,7 +15,7 @@ PjGenerationOptimizationTest >> testAnd [
 			test: y
 			whenTrue: one
 			whenFalse: falseNode}.
-	self assert:  inputAst asStringEquals: 'this.', PjTranspiler pharoJsSelectorPrefix, 'foo_(true==y&&1)'.
+	self assert:  inputAst asStringEquals: 'this.', self selectorsPrefix, 'foo_(true==y&&1)'.
 
 ]
 
@@ -45,12 +45,12 @@ PjGenerationOptimizationTest >> testIfNil [
 		PjIfNilNode 
 			test: (self apply: y selector: #foo)
 			whenNil: one).
-	self assert: inputAst asStringEquals: 'return $asNil$(y).', PjTranspiler pharoJsSelectorPrefix, 'foo()==undefined?1:undefined'.
+	self assert: inputAst asStringEquals: 'return $asNil$(y).', self selectorsPrefix, 'foo()==undefined?1:undefined'.
 
 	inputAst := PjIfNilNode 
 			test: (self apply: y selector: #foo)
 			whenNil: one.
-	self assert: inputAst asStringEquals: 'if($asNil$(y).', PjTranspiler pharoJsSelectorPrefix, 'foo()==undefined)1'.
+	self assert: inputAst asStringEquals: 'if($asNil$(y).', self selectorsPrefix, 'foo()==undefined)1'.
 
 ]
 
@@ -69,7 +69,7 @@ PjGenerationOptimizationTest >> testIfNilCaseForIfNilIfNotNil [
 			whenNil: one).
 	self
 		assert: expectedAst
-		asStringEquals: 'return ($1=$asNil$(y).', PjTranspiler pharoJsSelectorPrefix, 'foo())==undefined?1:$1'
+		asStringEquals: 'return ($1=$asNil$(y).', self selectorsPrefix, 'foo())==undefined?1:$1'
 
 ]
 
@@ -88,7 +88,7 @@ PjGenerationOptimizationTest >> testIfNotNil [
 			whenNotNil: tempVariable).
 	self
 		assert: expectedAst
-		asStringEquals: 'return (x=$asNil$(y).', PjTranspiler pharoJsSelectorPrefix, 'foo())==undefined?undefined:x'.
+		asStringEquals: 'return (x=$asNil$(y).', self selectorsPrefix, 'foo())==undefined?undefined:x'.
 
 	expectedAst := PjReturnNode expression: (
 		PjIfNotNilNode 
@@ -98,14 +98,14 @@ PjGenerationOptimizationTest >> testIfNotNil [
 			whenNotNil: (self apply: tempVariable selector: #foo nonNil: true)).
 	self
 		assert: expectedAst
-		asStringEquals: 'return (x=$asNil$(y).', PjTranspiler pharoJsSelectorPrefix, 'foo())==undefined?undefined:x.', PjTranspiler pharoJsSelectorPrefix, 'foo()'.
+		asStringEquals: 'return (x=$asNil$(y).', self selectorsPrefix, 'foo())==undefined?undefined:x.', self selectorsPrefix, 'foo()'.
 
 	expectedAst := PjIfNotNilNode 
 			test: (PjAssignNode
 				target: tempVariable
 				expression: (self apply: y selector: #foo nonNil: false))
 			whenNotNil: tempVariable.
-	self assert: expectedAst asStringEquals: 'if((x=$asNil$(y).', PjTranspiler pharoJsSelectorPrefix, 'foo())!=undefined)x'.
+	self assert: expectedAst asStringEquals: 'if((x=$asNil$(y).', self selectorsPrefix, 'foo())!=undefined)x'.
 
 	expectedAst := PjIfNotNilNode 
 			test: (PjAssignNode
@@ -114,7 +114,7 @@ PjGenerationOptimizationTest >> testIfNotNil [
 			whenNotNil: (self apply: tempVariable selector: #foo nonNil: true).
 	self
 		assert: expectedAst
-		asStringEquals: 'if((x=$asNil$(y).', PjTranspiler pharoJsSelectorPrefix, 'foo())!=undefined)x.', PjTranspiler pharoJsSelectorPrefix, 'foo()'.
+		asStringEquals: 'if((x=$asNil$(y).', self selectorsPrefix, 'foo())!=undefined)x.', self selectorsPrefix, 'foo()'.
 
 	expectedAst := PjIfNotNilNode
 		test: y
@@ -140,7 +140,7 @@ PjGenerationOptimizationTest >> testIfNotNilCaseForIfNilIfNotNil [
 				expression: (self apply: y selector: #foo)) 
 			whenNotNil: tempVariable
 			whenNil: one).
-	self assert: expectedAst asStringEquals: 'return (x=$asNil$(y).', PjTranspiler pharoJsSelectorPrefix, 'foo())==undefined?1:x'.
+	self assert: expectedAst asStringEquals: 'return (x=$asNil$(y).', self selectorsPrefix, 'foo())==undefined?1:x'.
 
 	expectedAst := PjReturnNode expression: (
 		PjIfNilIfNotNilNode 
@@ -149,7 +149,7 @@ PjGenerationOptimizationTest >> testIfNotNilCaseForIfNilIfNotNil [
 				expression: (self apply: y selector: #foo))
 			whenNotNil: (self apply: tempVariable selector: #foo nonNil: true)
 			whenNil: one).
-	self assert: expectedAst asStringEquals: 'return (x=$asNil$(y).', PjTranspiler pharoJsSelectorPrefix, 'foo())==undefined?1:x.', PjTranspiler pharoJsSelectorPrefix, 'foo()'.
+	self assert: expectedAst asStringEquals: 'return (x=$asNil$(y).', self selectorsPrefix, 'foo())==undefined?1:x.', self selectorsPrefix, 'foo()'.
 
 	expectedAst := PjIfNilIfNotNilNode 
 			test: (PjAssignNode
@@ -157,7 +157,7 @@ PjGenerationOptimizationTest >> testIfNotNilCaseForIfNilIfNotNil [
 				expression: (self apply: y selector: #foo))
 			whenNotNil: tempVariable
 			whenNil: one .
-	self assert: expectedAst asStringEquals: 'if((x=$asNil$(y).', PjTranspiler pharoJsSelectorPrefix, 'foo())==undefined)1;else x'.
+	self assert: expectedAst asStringEquals: 'if((x=$asNil$(y).', self selectorsPrefix, 'foo())==undefined)1;else x'.
 
 	expectedAst := PjIfNilIfNotNilNode 
 			test: (PjAssignNode
@@ -165,7 +165,7 @@ PjGenerationOptimizationTest >> testIfNotNilCaseForIfNilIfNotNil [
 				expression: (self apply: y selector: #foo))
 			whenNotNil: (self apply: tempVariable selector: #foo nonNil: true)
 			whenNil: one.
-	self assert: expectedAst asStringEquals: 'if((x=$asNil$(y).', PjTranspiler pharoJsSelectorPrefix, 'foo())==undefined)1;else x.', PjTranspiler pharoJsSelectorPrefix, 'foo()'
+	self assert: expectedAst asStringEquals: 'if((x=$asNil$(y).', self selectorsPrefix, 'foo())==undefined)1;else x.', self selectorsPrefix, 'foo()'
 
 ]
 
@@ -205,7 +205,7 @@ PjGenerationOptimizationTest >> testOr [
 			test: y
 			whenTrue: trueNode
 			whenFalse: one}.
-	self assert:  inputAst asStringEquals: 'this.', PjTranspiler pharoJsSelectorPrefix, 'foo_(true==y||1)'.
+	self assert:  inputAst asStringEquals: 'this.', self selectorsPrefix, 'foo_(true==y||1)'.
 
 ]
 
@@ -219,8 +219,8 @@ PjGenerationOptimizationTest >> testSequence [
 			test: (self apply: x selector: #foo)
 			whenTrue: one
 			whenFalse: two}.
-	self assert: (PjIfTrueNode test: inputAst whenTrue: one) asStringEquals: 'if(true==(1,2,(true==$asNil$(x).', PjTranspiler pharoJsSelectorPrefix, 'foo()?1:2)))1'.
-	self assert: inputAst asStringEquals: '{1;2;if(true==$asNil$(x).', PjTranspiler pharoJsSelectorPrefix, 'foo())1;else 2}'.
+	self assert: (PjIfTrueNode test: inputAst whenTrue: one) asStringEquals: 'if(true==(1,2,(true==$asNil$(x).', self selectorsPrefix, 'foo()?1:2)))1'.
+	self assert: inputAst asStringEquals: '{1;2;if(true==$asNil$(x).', self selectorsPrefix, 'foo())1;else 2}'.
 
 	inputAst := self simpleBlock: {
 		PjIfTrueIfFalseNode 

--- a/Pharo/PharoJsTranspilerOptimization/PjOptimizedClassTranspilationTest.class.st
+++ b/Pharo/PharoJsTranspilerOptimization/PjOptimizedClassTranspilationTest.class.st
@@ -13,7 +13,7 @@ PjOptimizedClassTranspilationTest >> setUp [
 { #category : #testing }
 PjOptimizedClassTranspilationTest >> testBlocksAndReturns [
 	|prefix|
-	prefix := PjTranspiler pharoJsSelectorPrefix.
+	prefix := transpiler pharoJsSelectorPrefix.
 	self jsCode: (self convertClass: PjClassForTranspilationTest).
 	self assertInstanceMethod: #whileNotAtEnd
 		equals: '(){this.', prefix, 'm_(function(x){while(true==$asNil$(x).', prefix, 'm1()){}});while(true==this.', prefix, 'm2()){}return 42}'.
@@ -25,7 +25,7 @@ PjOptimizedClassTranspilationTest >> testBlocksAndReturns [
 { #category : #testing }
 PjOptimizedClassTranspilationTest >> testSubIf [
 	self jsCode: (self convertClass: PjClassForTranspilationTest).
-	self assertClassMethod: #setupMessage equals: '(){return $asNil$((this===JsClass?"":"Sorry, ")).', PjTranspiler pharoJsSelectorPrefix, '44_("Click anywhere")}'.
-	self assertClassMethod: #click: equals: '(ev){var m;var $_err_$={};try{m=($1=this.', PjTranspiler pharoJsSelectorPrefix, 'setupMessage())==undefined?',PjCore throwFunctionName,'($_err_$=this):$1;return m}catch(e){if(e===$_err_$)return e;throw e}}'.
+	self assertClassMethod: #setupMessage equals: '(){return $asNil$((this===JsClass?"":"Sorry, ")).', transpiler pharoJsSelectorPrefix, '44_("Click anywhere")}'.
+	self assertClassMethod: #click: equals: '(ev){var m;var $_err_$={};try{m=($1=this.', transpiler pharoJsSelectorPrefix, 'setupMessage())==undefined?',PjCore throwFunctionName,'($_err_$=this):$1;return m}catch(e){if(e===$_err_$)return e;throw e}}'.
 
 ]

--- a/Pharo/PharoJsTranspilerOptimization/PjOptimizedCoreLibrariesTranspilationTest.class.st
+++ b/Pharo/PharoJsTranspilerOptimization/PjOptimizedCoreLibrariesTranspilationTest.class.st
@@ -13,7 +13,7 @@ PjOptimizedCoreLibrariesTranspilationTest >> setUp [
 { #category : #testing }
 PjOptimizedCoreLibrariesTranspilationTest >> testPjLoggingEvaluatorWebSocketDelegateClass [
 	|prefix|
-	prefix := PjTranspiler pharoJsSelectorPrefix.
+	prefix := transpiler pharoJsSelectorPrefix.
 	self jsCode: (self convertClass: PjLoggingEvaluatorWebsocketDelegate).
 	self assertInstanceMethod: #log: equals: '(aString){var logElement,br,text,$_self_$=this;(function(){var $1;br=$asNil$(document).', prefix,'createElement_("BR");text=$asNil$(document).', prefix,'createTextNode_(aString);logElement=$_self_$.', prefix,'logElement();return ($1=$asNil$(logElement),$1.', prefix,'insertBefore_node_(br,$asNil$(logElement).', prefix,'firstChild()),$1.', prefix,'insertBefore_node_(text,$asNil$(logElement).', prefix,'firstChild()))}).', prefix,'on_do_(Error,function(){return $asNil$(console).', prefix,'log_(aString)});return this}'
 ]
@@ -21,7 +21,7 @@ PjOptimizedCoreLibrariesTranspilationTest >> testPjLoggingEvaluatorWebSocketDele
 { #category : #testing }
 PjOptimizedCoreLibrariesTranspilationTest >> testPjStringClass [
 	|prefix|
-	prefix := PjTranspiler pharoJsSelectorPrefix.
+	prefix := transpiler pharoJsSelectorPrefix.
 	self jsCode: (self convertClass: PjString).
 self assertInstanceMethod: #isLetter equals: '(){return $asNil$(this.', prefix,'letterCharCodes()).', prefix,'includes_(this.charCodeAt(0))}'
 


### PR DESCRIPTION
pharoJsSelectorPrefix is now on a per-app basismethods named by <jsGenerator: #xxx:> take a transpiler parameter which allows them to parameterize betteradded a <jsLiteralGenerator> pragma that is useful for methods that want to do a complex calculation on the Pharo side (access a file, transpile something, etc.) but only care about the final result on the JS side