### PR TITLE
 Introduced a test asserting that one of the two combinations is produced

### DIFF
--- a/Pharo/PharoJsSerializationTest/PhxBridgedJsonSerialisationTests.class.st
+++ b/Pharo/PharoJsSerializationTest/PhxBridgedJsonSerialisationTests.class.st
@@ -143,16 +143,43 @@ PhxBridgedJsonSerialisationTests >> testSerializeEmptyObject [
 ]
 
 { #category : #tests }
-PhxBridgedJsonSerialisationTests >> testSerializeIdentityDictionary [
+PhxBridgedJsonSerialisationTests >> testSerializeIdentityDictionary1Entry [
+	self
+		assertAllWithInstantiationBlock: [ | d |
+			d := IdentityDictionary new.
+			d at: 'b' put: '123'.
+			d asPhxJsonString ]
+		literal: '{"class":"IdentityDictionary","instance":{"b":"123"}}'
+		testEq: true
+		test4Stages: true.
 	self
 		assertAllWithInstantiationBlock: [ | d |
 			d := IdentityDictionary new.
 			d at: 'a' put: 'abc'.
-			d at: 'b' put: '123'.
 			d asPhxJsonString ]
-		literal: '{"class":"IdentityDictionary","instance":{"a":"abc","b":"123"}}'
+		literal: '{"class":"IdentityDictionary","instance":{"a":"abc"}}'
 		testEq: true
 		test4Stages: true
+]
+
+{ #category : #tests }
+PhxBridgedJsonSerialisationTests >> testSerializeIdentityDictionary2Entries [
+	"Entries in a dictionary are unordered. So, serialization may result into different valid results."
+	| serializationBlock validSerializationStrings jsSerialization pharoSerialization |
+	serializationBlock := [ | d |
+			d := IdentityDictionary new.
+			d at: 'a' put: 'abc'.
+			d at: 'b' put: '123'.
+			d asPhxJsonString ].
+	validSerializationStrings := #(
+		'{"class":"IdentityDictionary","instance":{"a":"abc","b":"123"}}'
+		'{"class":"IdentityDictionary","instance":{"b":"123","a":"abc"}}').
+	jsSerialization := self evalBlock: serializationBlock.
+	pharoSerialization := serializationBlock value.
+	{jsSerialization. pharoSerialization} do: [ : serialization |
+		self assert: (validSerializationStrings includes: serialization)
+	]
+
 ]
 
 { #category : #tests }


### PR DESCRIPTION
Replaced intermittent failing test wit 2 tests. One involving a dictionary with 1 entry, and the other involves a dictionary with 2 entries. 
To test the serialization of the dictionary with 2 entries, we check that the resulting string belongs to the set of valid combinations.