### PR TITLE
timesRepeatOptimization failing on Pharo10

### DIFF
--- a/Pharo/PharoJs-Base-Transpiler-Optimizations-Tests/PjConversionOptimizationTest.class.st
+++ b/Pharo/PharoJs-Base-Transpiler-Optimizations-Tests/PjConversionOptimizationTest.class.st
@@ -574,6 +574,7 @@ PjConversionOptimizationTest >> testTimesRepeat [
 					target: a
 					expression: one
 			}).
+	self shouldnt: [ self convertFirstStatementOfBlock:  [ in timesRepeat: [|b| b := 1]]] raise: PjJavascriptTranspilationError  
 ]
 
 { #category : #testing }

--- a/Pharo/PharoJs-Base-Transpiler-Optimizations/PjTimesRepeatOptimization.class.st
+++ b/Pharo/PharoJs-Base-Transpiler-Optimizations/PjTimesRepeatOptimization.class.st
@@ -9,6 +9,7 @@ PjTimesRepeatOptimization >> convertReceiver: receiver args: args [
 	| from to body fromName toName |
 	self astConverter isInExpression ifTrue: [ ^ nil ].
 	args last isBlock ifFalse: [ ^ nil ].
+	args last temporaries ifNotEmpty: [ ^ nil ].
 	self inExpressionDo: [
 		fromName := self tempName.
 		from := PjAssignNode


### PR DESCRIPTION
On Pharo10 the timesRepeatOptimization is failing when tempVar are declared inside the block.

This is not proper fix but a terrible workaround that bypass optimization when there is a temp in the block.
