### PR TITLE
Using PjTemporaryNode instead of RBVariable when declaring inlined block temp variable

### DIFF
--- a/Pharo/PharoJs-Base-Transpiler/PjAstConverter.class.st
+++ b/Pharo/PharoJs-Base-Transpiler/PjAstConverter.class.st
@@ -621,7 +621,7 @@ PjAstConverter >> visitInlineBlock: aRBProgramNode [
 	aRBProgramNode temporaryNames do: [ : each |
 		extraTempVariablesToDeclare add: each.
 		loopNestingLevel >0 ifTrue: [
-			variable := RBVariableNode named: each.
+			variable := PjTemporaryNode named: each.
 			statements addFirst: (RBAssignmentNode variable: variable value: RBLiteralValueNode new).
 	]].
 	^ (self visitAllNodes: statements) asSimpleNode.


### PR DESCRIPTION
This will fix the issue with inlined block temp variable. And many other tests. 