### PR TITLE
we should collect resources from the super class

### DIFF
--- a/Pharo/PharoJs-TestFramework/PjAppTestCase.class.st
+++ b/Pharo/PharoJs-TestFramework/PjAppTestCase.class.st
@@ -106,7 +106,7 @@ PjAppTestCase >> resetInstanceVariables [
 
 { #category : #accessing }
 PjAppTestCase >> resources [
-	^{self bridgeResourceClass}
+	^super resources, {self bridgeResourceClass}
 ]
 
 { #category : #running }


### PR DESCRIPTION
Resources can be declared in `OneTestCase>resources` or in `OneTestCase class>>resources`.
`TestCase>resource` make combines both class side and instance side declaration of resources. 
By not calling `super` in this context we prevent any resource from the class side `resource` method to be called.