### PR TITLE
Suggestion to support method import using pragma.

### DIFF
--- a/Pharo/PharoJs-Base-Exporter/PjDependentTranspiler.class.st
+++ b/Pharo/PharoJs-Base-Exporter/PjDependentTranspiler.class.st
@@ -138,17 +138,26 @@ PjDependentTranspiler >> generateCodeStringFrom: jsAst [
 
 { #category : #transpiling }
 PjDependentTranspiler >> importMethodsAll: aCollection forClass: aClass [
+
 	| importMethods |
 	importMethods := Dictionary new.
-	aCollection
-		do: [ :aSymbol | 
-			(aClass instanceSide hasClassMethod: aSymbol)
-				ifTrue: [ (aClass instanceSide perform: aSymbol)
-						associationsDo: [ :assoc | 
-							importMethods
-								at: assoc key
-								ifPresent: [ :im | im value addAll: assoc value ]
-								ifAbsent: [ importMethods at: assoc key put: assoc value asSet ] ] ] ].
+	aCollection do: [ :aSymbole |
+		aClass classSide pragmas collect: [ :aPragma |
+			aPragma key = aSymbole ifTrue: [
+				(aClass instanceSide perform: aPragma method selector)
+					associationsDo: [ :assoc |
+						importMethods
+							at: assoc key
+							ifPresent: [ :im | im value addAll: assoc value ]
+							ifAbsent: [ importMethods at: assoc key put: assoc value asSet ] ] ] ] ].
+	aCollection do: [ :aSymbol |
+		(aClass instanceSide hasClassMethod: aSymbol) ifTrue: [
+			(aClass instanceSide perform: aSymbol) associationsDo: [ :assoc |
+				importMethods
+					at: assoc key
+					ifPresent: [ :im | im value addAll: assoc value ]
+					ifAbsent: [ importMethods at: assoc key put: assoc value asSet ] ] ] ].
+
 	^ importMethods
 ]
 


### PR DESCRIPTION
If my project requires `String>>subStrings:`. 
And a library it utilize requires `String>>whatever`. 

Both package will declare extensions on the class `PjString` to override the method `jsTranspilationImportMethods` causing conflicts. 

Relying on pramas instead allows developers to name the extension method on `PjString` differently (eg. `PjString>>myProjectMethodToImport`). 

No more conflict and no need to add `substrings:` or `whatever` to pharoJSCore.