### PR TITLE
Add missing source paths to metacello

### DIFF
--- a/Pharo/BaselineOfPharoJS/BaselineOfPharoJS.class.st
+++ b/Pharo/BaselineOfPharoJS/BaselineOfPharoJS.class.st
@@ -138,9 +138,9 @@ BaselineOfPharoJS >> prerequisites: spec [
 
 	spec
 		baseline: 'PharoExtra'
-		with: [ spec repository: 'github://bouraqadi/PharoMisc:pharo12' ];
+		with: [ spec repository: 'github://bouraqadi/PharoMisc:pharo12/Pharo' ];
 		baseline: 'LightweightObserver'
-		with: [ spec repository: 'github://bouraqadi/PharoMisc:pharo12' ];
+		with: [ spec repository: 'github://bouraqadi/PharoMisc:pharo12/Pharo' ];
 		baseline: 'Seaside3'
 		with: [
 			spec repository: 'github://SeasideSt/Seaside:master/repository' ].

--- a/Pharo/BaselineOfPharoJS/BaselineOfPharoJS.class.st
+++ b/Pharo/BaselineOfPharoJS/BaselineOfPharoJS.class.st
@@ -148,5 +148,5 @@ BaselineOfPharoJS >> prerequisites: spec [
 	"Prerequisite Packages"
 	spec
 		package: 'Zinc-WebSocket-Core'
-		with: [ spec repository: 'github://svenvc/zinc' ]
+		with: [ spec repository: 'github://svenvc/zinc/repository' ]
 ]


### PR DESCRIPTION
For a full repository spec in metacello the source path is needed. This works in image without because of the .project file but loading it from commandline and especially without git integration does not work without